### PR TITLE
Review 'assessment duration' logic

### DIFF
--- a/R/aggregation_core_model.R
+++ b/R/aggregation_core_model.R
@@ -14,7 +14,7 @@
 #'   - kg (unit)/head/day for non-production variables
 #'   - kg/cohort/assessment duration for production variables
 #' @param size Numeric vector. Number of heads in the specific cohort.
-#' @param assessment_duration Numeric vector. Duration of the assessment (days).
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #' @param variable_type Character vector. Variable group classification:
 #'   - `"Production"`: Production outputs (already at cohort level)
 #'   - `"Emissions"`, `"Feed"`, `"NitrogenBalance"`: Per-head-per-day values

--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -44,7 +44,7 @@ calc_energy_allocation_milk <- function(
 #' @param cohort_code Character scalar. Cohort identifier (e.g., "FA", "FS", "FJ", "MA", "MS", "MJ").
 #' @param slaughter_liveweight Numeric scalar. Slaughter liveweight (kg).
 #' @param birth_liveweight Numeric scalar. Birthweight (kg).
-#' @param meat_output_liveweight Numeric scalar. Liveweight meat output (kg).
+#' @param output_meat_production_liveweight Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).
 #'
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export
@@ -53,7 +53,7 @@ calc_energy_allocation_meat <- function(
     cohort_code,
     slaughter_liveweight,
     birth_liveweight,
-    meat_output_liveweight
+    output_meat_production_liveweight
 ) {
   validate_allocation_meat_inputs(
     animal, cohort_code,
@@ -121,7 +121,7 @@ calc_energy_allocation_meat <- function(
   }
 
   # Multiply specific energy by meat output to get total energy allocation
-  energy_allocation_meat <- specific_energy_meat * meat_output_liveweight
+  energy_allocation_meat <- specific_energy_meat * output_meat_production_liveweight
 
   return(energy_allocation_meat)
 }

--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -3,7 +3,7 @@
 #' Converts fat- and protein-corrected milk output into the megajoule demand used in the allocation workflow.
 #' The formula calculates energy density based on standard milk composition and multiplies by production.
 #'
-#' @param milk_fpcm_output Numeric scalar. Fat- and protein-corrected milk production (kg).
+#' @param milk_fpcm_output Numeric scalar. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period). Default fat and protein content=0.04 and 0.033.
 #' @param standard_protein Numeric scalar. Reference protein content (g per 100 g milk).
 #' @param standard_fat Numeric scalar. Reference fat content (g per 100 g milk).
 #' @param standard_lactose Numeric scalar. Reference lactose content (g per 100 g milk).
@@ -57,7 +57,7 @@ calc_energy_allocation_meat <- function(
 ) {
   validate_allocation_meat_inputs(
     animal, cohort_code,
-    slaughter_liveweight, birth_liveweight, meat_output_liveweight
+    slaughter_liveweight, birth_liveweight, output_meat_production_liveweight
   )
 
   # Default fallback
@@ -133,7 +133,7 @@ calc_energy_allocation_meat <- function(
 #' @param animal Character scalar. Species code (e.g., "GTS", "SHP", "CML").
 #' @param fibre_energy_requirement Numeric scalar. Fibre energy demand (MJ per head per day).
 #' @param ratio_ne_to_me Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).
-#' @param assessment_duration Numeric scalar. Assessment duration (days).
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #'
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export
@@ -168,7 +168,7 @@ calc_energy_allocation_fibre <- function(
 #' @param animal Character scalar. Species code (e.g., "CML" for camelids).
 #' @param work_energy_requirement Numeric scalar. Work energy demand (MJ per head per day).
 #' @param ratio_ne_to_me Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).
-#' @param assessment_duration Numeric scalar. Assessment duration (days).
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #'
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export

--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -141,7 +141,7 @@ calc_energy_allocation_fibre <- function(
     animal,
     fibre_energy_requirement,
     ratio_ne_to_me,
-    assessment_duration = 365
+    assessment_duration
 ) {
   validate_allocation_fibre_inputs(
     animal, fibre_energy_requirement, ratio_ne_to_me, assessment_duration
@@ -176,7 +176,7 @@ calc_energy_allocation_work <- function(
     animal,
     work_energy_requirement,
     ratio_ne_to_me,
-    assessment_duration = 365
+    assessment_duration
 ) {
   validate_allocation_work_inputs(
     animal, work_energy_requirement, ratio_ne_to_me, assessment_duration

--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -1,14 +1,65 @@
 #' Milk Energy Requirement for Allocation
 #'
-#' Converts fat- and protein-corrected milk output into the megajoule demand used in the allocation workflow.
-#' The formula calculates energy density based on standard milk composition and multiplies by production.
+#' Calculates the net energy demand (MJ) required to produce total fat-protein-corrected milk (FPCM) over the assessment period.
 #' 
-#' @param milk_fpcm_output Numeric scalar. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period). Default fat and protein content=0.04 and 0.033.
-#' @param standard_protein Numeric scalar. Reference protein content (g per 100 g milk).
-#' @param standard_fat Numeric scalar. Reference fat content (g per 100 g milk).
-#' @param standard_lactose Numeric scalar. Reference lactose content (g per 100 g milk).
+#' This function provides the milk-related energy term used in a biophysical
+#' allocation framework to apportion emissions between milk and other co-products
+#' in multifunctional livestock production systems.
+#'
+#' The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+#' FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+#'
+#' @param milk_fpcm_output Numeric scalar. Total fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period). 
 #' 
-#' @return Numeric scalar. Energy requirements in megajoules.
+#' Default fat and protein content=0.04 and 0.033.
+#' @param standard_protein Numeric. Standard protein content of milk, used to calculate Fat-protein-corrected milk (FPCM), (kg protein/kg milk). 
+#' 
+#' Default used=0.033.
+#' @param standard_fat Numeric. Standard fat content of milk, used to calculate Fat-protein-corrected milk (FPCM), (kg fat/kg milk). 
+#' 
+#' Default used=0.04.
+#' @param standard_lactose Numeric. Standard lactose content of milk, used to calculate Fat-protein-corrected milk (FPCM) , (kg lactose/kg milk). 
+#' 
+#' Default used=0.048.
+#'
+#' @return Numeric scalar. Energy required to produce total milk output by cohort (MJ/cohort/assessment period).
+#' 
+#' Non-zero values are applicable only to milk-producing species and cohorts (species=CTL, BFL, CML, SHP, GTS; cohorts=AF).
+#' All other species–cohort combinations are assigned a value of 0.
+#' 
+#' @details
+#' In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+#' biophysical relationships may be used to assign shared inputs and outputs of a
+#' single production unit to individual products or sub-units. In livestock systems,
+#' this includes apportioning shared feed and energy use according to physiological
+#' energy requirements (e.g., net energy for lactation, growth..etc.). If the
+#' resulting process remains multifunctional, these energy terms may subsequently
+#' be used to derive allocation factors among co-products.
+#' 
+#' @references 
+#' ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+#' guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+#'
+#' IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+#' Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+#'
+#' Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+#' Critical discussion of the IDF’s standard methodology. Proceedings of the
+#' 12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+#' pp. 83–89, 13–16 October, Berlin, Germany.
+#'
+#' FAO. 2016a. Environmental performance of large ruminant supply chains:
+#' Guidelines for assessment. Livestock Environmental Assessment and Performance
+#' (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+#' supply chains: Guidelines for assessment. Livestock Environmental Assessment
+#' and Performance (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+#' chains: Guidelines for assessment. Livestock Environmental Assessment and
+#' Performance (LEAP) Partnership. FAO, Rome, Italy.
+#' 
 #' @export
 calc_energy_allocation_milk <- function(
     milk_fpcm_output,
@@ -37,16 +88,122 @@ calc_energy_allocation_milk <- function(
 
 #' Meat Energy Requirement for Allocation
 #' 
-#' Applies species- and cohort-specific equations to compute the megajoules required to produce meat output.
-#' The calculation follows species-specific formulas to determine energy per kg liveweight, then multiplies by output.
-#'
-#' @param animal Character scalar. Species code (e.g., "CTL", "BFL", "CML", "SHP", "GTS", "PGS").
-#' @param cohort_code Character scalar. Cohort identifier (e.g., "FA", "FS", "FJ", "MA", "MS", "MJ").
-#' @param slaughter_liveweight Numeric scalar. Slaughter liveweight (kg).
-#' @param birth_liveweight Numeric scalar. Birthweight (kg).
-#' @param output_meat_production_liveweight Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).
+#' Calculates the net energy demand (MJ) associated with meat production (expressed as
+#' liveweight output) over the assessment period for a given species and cohort.
 #' 
-#' @return Numeric scalar. Energy requirements in megajoules.
+#' This function provides the meat-related energy term used in a biophysical
+#' allocation framework to apportion emissions between milk and other co-products
+#' in multifunctional livestock production systems.
+#'
+#' The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+#' FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+#' 
+#'
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#' @param cohort_code Character scalar.Sex- and age-specific cohort code describing the
+#'   production stage of the animals. Supported values include:
+#'   \itemize{
+#'     \item \code{FA}: adult females (from age at first parturition)
+#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
+#'     \item \code{FJ}: juvenile females (from birth to weaning)
+#'     \item \code{MA}: adult males (from age at first breeding)
+#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
+#'     \item \code{MJ}: juvenile males (from birth to weaning)
+#'   }
+#' @param slaughter_liveweight Numeric scalar. Live weight at slaughter for animals removed from the cohort (kg).
+#' @param birth_liveweight Numeric scalar. Live weight of the animal at birth (kg).
+#' @param output_meat_production_liveweight Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).
+#' @param ratio_ne_to_me Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.
+#'
+#' @return Numeric scalar. Energy required by a given sex–age cohort for total meat output by cohort during 
+#' the assessment period, equal to the energy needed to produce all live-weight gain to reach the target slaughter weight (MJ/cohort/assessment period). 
+#' 
+#' Non-zero values are applicable to all species/cohorts where growth is modelled. For
+#' pigs (\code{PGS}), the function returns \code{NA} by design.
+#' 
+#' 
+#' @details
+#' In accordance with ISO 14044:2006
+#' (Section 4.3.4.2, Step 2), known processing or biophysical relationships may be
+#' used to assign shared inputs and outputs of a single production unit to
+#' individual products or sub-units. In livestock systems, this includes
+#' apportioning shared feed and energy use according to physiological energy
+#' requirements (e.g., net energy for lactation or growth). If the process
+#' remains multifunctional after such assignment, the resulting energy terms
+#' may be used to derive allocation factors among co-products.
+#'
+#' The objective of this function is to estimate the net
+#' energy required to produce the meat obtained during the assessment period.
+#' This is achieved by quantifying the physiological energy required for animals
+#' to grow from birth weight to slaughter weight for each species and cohort.
+#'
+#'
+#' Total energy required for meat production over the assessment period ((\code{specific_energy_meat}is then
+#' calculated as:
+#'
+#' \itemize{
+#'   \item \code{energy_allocation_meat = specific_energy_meat * output_meat_production_liveweight}
+#' }
+#'
+#' where 
+#' 
+#' \code{output_meat_production_liveweight} is the average
+#' net energy required to produce one kilogram of liveweight gain, accounting
+#' for differences in growth efficiency, metabolic scaling, and sex-specific
+#' growth patterns (MJ/kg live weight)
+#' 
+#' \code{specific_energy_meat} is the total liveweight of
+#' animals sold for meat during the assessment period, which is calculated with a specie-specific approach:
+#'
+#' \itemize{
+#'   \item \strong{For (\code{CTL}, \code{BFL}, \code{CML},
+#'   \code{SHP}, \code{GTS})}:
+#'   
+#'   Growth energy is calculated using species- and
+#'   cohort-specific biophysical relationships adapted from established growth
+#'   energy formulations (further details in \code{\link{?gleam::calc_net_energy_growth}}). 
+#'
+#'   \item \strong{For (\code{PGS})}:
+#'   
+#'   Growth energy is not calculated in this
+#'   function and \code{NA} is returned. In downstream processing,
+#'   \code{\link{calc_allocation_shares}} assigns 100% of the allocation to the
+#'   edible meat commodity for pig systems.
+#' }
+#' 
+#' @references 
+#' ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+#' guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+#'
+#' IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+#' Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+#'
+#' Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+#' Critical discussion of the IDF’s standard methodology. Proceedings of the
+#' 12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+#' pp. 83–89, 13–16 October, Berlin, Germany.
+#'
+#' FAO. 2016a. Environmental performance of large ruminant supply chains:
+#' Guidelines for assessment. Livestock Environmental Assessment and Performance
+#' (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+#' supply chains: Guidelines for assessment. Livestock Environmental Assessment
+#' and Performance (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+#' chains: Guidelines for assessment. Livestock Environmental Assessment and
+#' Performance (LEAP) Partnership. FAO, Rome, Italy.
+#' 
 #' @export
 calc_energy_allocation_meat <- function(
     animal,
@@ -129,14 +286,86 @@ calc_energy_allocation_meat <- function(
 
 #' Fibre Energy Requirement for Allocation
 #'
-#' Computes fibre energy demand over the assessment window, applying the camelid conversion factor when required.
-#'
-#' @param animal Character scalar. Species code (e.g., "GTS", "SHP", "CML").
-#' @param fibre_energy_requirement Numeric scalar. Fibre energy demand (MJ per head per day).
-#' @param ratio_ne_to_me Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).
-#' @param assessment_duration Numeric. Length of the assessment period (days)
+#' Calculates the net energy demand (MJ) associated with fibre production over the
+#' assessment period for fibre-producing species and cohorts.
 #' 
-#' @return Numeric scalar. Energy requirements in megajoules.
+#' 
+#' This function provides the fibre-related energy term used in a biophysical
+#' allocation framework to apportion emissions between milk and other co-products
+#' in multifunctional livestock production systems.
+#'
+#' The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+#' FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+#' 
+#' 
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#'   
+#' @param fibre_energy_requirement Numeric. Energy required for the synthesis of fibre for SHP, GTS and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for SHP and GTS and as metabolizable energy for CML (MJ/head/day).
+#' @param ratio_ne_to_me Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.
+#' @param assessment_duration Numeric. Length of the assessment period (days).
+#'
+#' @return Numeric scalar. Energy required to produce all fibre output by cohort (MJ/cohort/assessment period).
+#' 
+#' Non-zero values are expected only for fiber-producing species (CML, SHP, GTS) and assumed cohorts ("FA", "FS", "MA", "MS")
+#' 
+#' @details
+#' In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+#' biophysical relationships may be used to assign shared inputs and outputs of a
+#' single production unit to individual products or sub-units. In livestock systems,
+#' this includes apportioning shared feed and energy use according to physiological
+#' energy requirements (e.g., net energy for lactation, growth..etc.). If the
+#' resulting process remains multifunctional, these energy terms may subsequently
+#' be used to derive allocation factors among co-products.
+#' 
+#' 
+#' Total fibre-related energy over the assessment period is computed for
+#' fibre-producing species (\code{CML}, \code{SHP},
+#' \code{GTS}) and applicable cohorts (\code{"FA"}, \code{"FS"}, \code{"MA"},
+#' \code{"MS"}).
+#'
+#' The calculation is:
+#'
+#' \itemize{
+#'   \item \code{energy_allocation_fibre = fibre_energy_requirement * assessment_duration}
+#' }
+#'
+#' where \code{fibre_energy_requirement} represents the daily energy requirement
+#' for fibre production (MJ/head/day) and is obtained from
+#' \code{\link[gleam]{calc_net_energy_fibre}}.
+#' 
+#' @references 
+#' ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+#' guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+#'
+#' IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+#' Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+#'
+#' Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+#' Critical discussion of the IDF’s standard methodology. Proceedings of the
+#' 12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+#' pp. 83–89, 13–16 October, Berlin, Germany.
+#'
+#' FAO. 2016a. Environmental performance of large ruminant supply chains:
+#' Guidelines for assessment. Livestock Environmental Assessment and Performance
+#' (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+#' supply chains: Guidelines for assessment. Livestock Environmental Assessment
+#' and Performance (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+#' chains: Guidelines for assessment. Livestock Environmental Assessment and
+#' Performance (LEAP) Partnership. FAO, Rome, Italy.
+#' 
 #' @export
 calc_energy_allocation_fibre <- function(
     animal,
@@ -164,14 +393,80 @@ calc_energy_allocation_fibre <- function(
 
 #' Work Energy Requirement for Allocation
 #'
-#' Estimates energy expenditure on animal work for the assessment duration, adjusting camelid values when required.
+#' Calculates the net energy demand (MJ) associated with animal work over the
+#' assessment period for animals involved in draught power generation.
 #' 
-#' @param animal Character scalar. Species code (e.g., "CML" for camelids).
-#' @param work_energy_requirement Numeric scalar. Work energy demand (MJ per head per day).
-#' @param ratio_ne_to_me Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).
-#' @param assessment_duration Numeric. Length of the assessment period (days)
 #' 
-#' @return Numeric scalar. Energy requirements in megajoules.
+#' This function provides the work-related energy term used in a biophysical
+#' allocation framework to apportion emissions between milk and other co-products
+#' in multifunctional livestock production systems.
+#'
+#' The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+#' FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+#'
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#' @param work_energy_requirement Numeric. Energy required for work, used to estimate the energy required for draught power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
+#' @param ratio_ne_to_me Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.
+#' @param assessment_duration Numeric. Length of the assessment period (days).
+#'
+#' @return Numeric scalar. Energy required to provide all draught power (traction/work) by cohort (MJ/cohort/assessment period).
+#' 
+#' Non-zero values are expected only for fiber-producing species (CTL, BFL CML) and assumed cohorts ("MA").' 
+#' 
+#' @details
+#' In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+#' biophysical relationships may be used to assign shared inputs and outputs of a
+#' single production unit to individual products or sub-units. In livestock systems,
+#' this includes apportioning shared feed and energy use according to physiological
+#' energy requirements (e.g., net energy for lactation, growth..etc.). If the
+#' resulting process remains multifunctional, these energy terms may subsequently
+#' be used to derive allocation factors among co-products.
+#' 
+#' Total work-related energy is computed for species (\code{CTL}, \code{BFL}, \code{CML})
+#' and cohorts (\code{MA}) assumed to be potentially involved in draught power generation, and 
+#' is calculated as follows:
+#'
+#' \itemize{
+#'   \item \code{energy_allocation_work = work_energy_requirement * assessment_duration}
+#' }
+#'
+#' where \code{work_energy_requirement} represents the daily energy requirement for
+#' animal work (MJ/head/day) and is obtained from
+#' \code{\link[gleam]{calc_net_energy_work}}.
+#' 
+#' @references 
+#' ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+#' guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+#'
+#' IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+#' Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+#'
+#' Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+#' Critical discussion of the IDF’s standard methodology. Proceedings of the
+#' 12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+#' pp. 83–89, 13–16 October, Berlin, Germany.
+#'
+#' FAO. 2016a. Environmental performance of large ruminant supply chains:
+#' Guidelines for assessment. Livestock Environmental Assessment and Performance
+#' (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+#' supply chains: Guidelines for assessment. Livestock Environmental Assessment
+#' and Performance (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+#' chains: Guidelines for assessment. Livestock Environmental Assessment and
+#' Performance (LEAP) Partnership. FAO, Rome, Italy.
+#' 
 #' @export
 calc_energy_allocation_work <- function(
     animal,
@@ -197,15 +492,15 @@ calc_energy_allocation_work <- function(
 #' Aggregate Cohort-Level Data to Herd-Level
 #'
 #' This function aggregates a dataset from cohort level to herd level by summing
-#' specified variables over the defined ID columns.
+#' specified variables over the defined 'id' columns.
 #' 
-#' @param data A `data.table` containing cohort-level data.
-#' @param id_cols Character vector of ID variables (e.g., Animal_short, LPS_short, HerdType_short).@Yassine: this should be revised. Record_id should be used.
-#' @param vars_to_sum Character vector of column names to be summed during aggregation.
-#' @param cohort Character. Cohort code (e.g., "FJ", "MJ", "FS", "MS", "FA", "MA").
+#' @param data A `data.table` at cohort-level containing energy allocation variables and herd identifiers. Each row corresponds to a single sex–age cohort within a herd.
+#' @param id_cols Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd.
+#' @param vars_to_sum Character vector. Names of numeric cohort-level variables to be summed across cohorts to produce herd-level totals (e.g., energy_allocation_meat, energy_allocation_milk, energy_allocation_fibre, energy_allocation_work, energy_allocation_eggs)
+#' @param cohort Character. Name of the column identifying the sex–age cohort (e.g. FJ, FA, MJ, etc.).
 
 #'
-#' @return A `data.table` with summed values at the herd level.
+#' @return A `data.table` at herd scale, in which selected cohort-level variables have been summed across all cohorts belonging to the same herd, as defined by id_herd.
 #' @export
 #'
 
@@ -228,24 +523,92 @@ aggregate_cohort_to_herd <- function(data_cohort, id_cols, vars_to_sum, cohort) 
 
 #' Calculate Energy Allocation Shares for Livestock Commodities
 #'
-#' Computes allocation shares of energy required for meat, milk, fibre, work, and eggs
-#' based on total energy demand per output. 
+#' Calculates biophysical allocation fractions for commodities (meat, milk, fibre, work,
+#' eggs) based on their total energy requirements.
+#'
+#' These fractions represent the proportions of total environmental burdens (e.g., GHG
+#' emissions) that will be allocated to each commodity in subsequent steps of the
+#' assessment.
+#'
+#' The biophysical approach follows the IDF Global Carbon Footprint Standard for the
+#' Dairy Sector (IDF, 2022), adapted from Thoma and Nemecek (2020), and is consistent
+#' with FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c). It aligns with
+#' ISO 14044:2006 (Section 4.3.4.2, Step 2) by using underlying physical (energy-based)
+#' relationships to assign shared inputs and outputs in multifunctional livestock
+#' production systems.
 #' 
-#' @param animal Character vector of animal species codes (e.g., "CTL", "SHP", "PGS").
-#' @param energy_meat Numeric vector: Herd-level energy requirement for meat production (MJ).
-#' @param energy_milk Numeric vector: Herd-level energy requirement for milk production (MJ).
-#' @param energy_fibre Numeric vector: Herd-level energy requirement for fibre production (MJ).
-#' @param energy_work Numeric vector: Herd-level energy requirement for work (MJ).
-#' @param energy_eggs Numeric vector: Herd-level energy requirement for eggs (MJ). 
+#' 
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#' @param energy_meat Numeric. Energy required for total meat output by herd during 
+#' the assessment period, equal to the energy needed to produce all live-weight gain to reach the target slaughter weight (MJ/herd/assessment period). 
+#' @param energy_milk Numeric. Energy required to produce total milk output by herd (MJ/herd/assessment period).
+#' @param energy_fibre Numeric. Energy required to produce all fibre output by herd (MJ/herd/assessment period).
+#' @param energy_work Numeric vector. Energy required to provide all draught power (traction/work) by herd (MJ/herd/assessment period)
+#' @param energy_eggs Numeric vector: Energy required to produce eggs by the herd during the assessment period (MJ/herd/assessment period). 
 #'
 #' @return A named list of numeric vectors with same length as input, containing:
 #' \describe{
-#'   \item{allocation_share_meat}{Proportion of total energy allocated to meat}
-#'   \item{allocation_share_milk}{... to milk}
-#'   \item{allocation_share_fibre}{... to fibre}
-#'   \item{allocation_share_work}{... to work}
-#'   \item{allocation_share_eggs}{... to eggs}
+#'   \item{allocation_share_meat}{Numeric. Allocation share assigned to meat (fraction).}
+#'   \item{allocation_share_milk}{Numeric. Allocation share assigned to milk (fraction).}
+#'   \item{allocation_share_fibre}{Numeric. Allocation share assigned to fibre (fraction).}
+#'   \item{allocation_share_work}{Numeric. Allocation share assigned to work (fraction).}
+#'   \item{allocation_share_eggs}{Numeric. Allocation share assigned to eggs (fraction).}
 #' }
+#' 
+#' 
+#' @details
+#' In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+#' biophysical relationships may be used to assign shared inputs and outputs of a
+#' single production unit to individual products or sub-units. In livestock systems,
+#' this includes apportioning shared feed and energy use according to physiological
+#' energy requirements (e.g., net energy for lactation, growth..etc.). If the
+#' resulting process remains multifunctional, these energy terms may subsequently
+#' be used to derive allocation factors among co-products.
+#' 
+#' 
+#' This function calculates biophysical allocation
+#' fractions for commodities (meat, milk, fibre, work, eggs) for all species.
+#'
+#' \strong{Pig systems (\code{PGS}).} For pigs, allocation is not based on energy
+#' partitioning because pig production is treated as functionally single-output
+#' (edible meat). Consequently, 100% of the allocation is assigned to the meat
+#' commodity (meat share = 1; all other commodity shares = 0), independent of the
+#' energy inputs. 
+#'
+#' 
+#' @references 
+#' ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+#' guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+#'
+#' IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+#' Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+#'
+#' Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+#' Critical discussion of the IDF’s standard methodology. Proceedings of the
+#' 12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+#' pp. 83–89, 13–16 October, Berlin, Germany.
+#'
+#' FAO. 2016a. Environmental performance of large ruminant supply chains:
+#' Guidelines for assessment. Livestock Environmental Assessment and Performance
+#' (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+#' supply chains: Guidelines for assessment. Livestock Environmental Assessment
+#' and Performance (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+#' chains: Guidelines for assessment. Livestock Environmental Assessment and
+#' Performance (LEAP) Partnership. FAO, Rome, Italy.
+#' 
 #' @export
 #' 
 calc_allocation_shares <- function(animal,
@@ -292,16 +655,18 @@ calc_allocation_shares <- function(animal,
 
 #' Assign Allocation Shares to Emission Variables by Commodity
 #'
-#' Expands an allocation table so that each commodity is combined with each emission source.
+#'# This function operationalizes commodity-level allocation of emissions by combining each commodity with each emission source
+#' and applying predefined allocation rules (see details).
+#' 
 #' Then enforces the allocation of emissions from manure burned as fuel and deposited on pasture
 #' to be **100% to the commodity "Other"**.
 #'
 #' @param allocation_herd_long A `data.table` containing a commodity column (levels=Eggs, Milk, Meat, Work, Fibre..) and an allocation share column.
-#' @param emissions_vars Character vector of names of emission variable sources to assign to different emission shares (e.g. `"ch4_enteric"`, `"direct_n2o_manure_other"`).
-#' @param commodities Character vector of commodity names to create combinations for. (e.g., "Other","Milk","Meat","Fibre","Work","Eggs")
-#' @param excluded_vars Character vector of emission sources that must be allocated fully to `"Other"`.
-#' @param commodity_col Character scalar. Name of the commodity column in the dataset `allocation_herd_long` (e.g. `"commodity_name"`).
-#' @param allocation_col Character scalar. Name of the allocation share column in the dataset `allocation_herd_long` (e.g. `"allocation_share"`).
+#' @param emissions_vars Character vector. Names of emission variables to which allocation should be applied (e.g., "ch4_enteric","ch4_manure_pasture","ch4_manure_burned","ch4_manure_other",         "direct_n2o_manure_pasture","direct_n2o_manure_burned","direct_n2o_manure_other", "indirect_n2o_manure_burned","indirect_n2o_manure_pasture","indirect_n2o_manure_other")
+#' @param commodities Character vector. List of commodity categories to which emissions may be allocated. List=c("Other","Milk","Meat","Fibre","Work","Eggs")
+#' @param excluded_vars Character vector. Emission variables that should not be allocated across commodities, even if they appear in emissions_vars ( e.g., "ch4_manure_pasture","ch4_manure_burned"..)
+#' @param commodity_col Character. Name of the column in `allocation_herd_long` identifying the commodity category.
+#' @param allocation_col Character. Name of the column in `allocation_herd_long` containing the allocation share to be applied.
 #'
 #' @return A `data.table` equal to `allocation_herd_long` expanded over all `emissions_vars`,
 #' with enforced allocation rules:
@@ -310,6 +675,47 @@ calc_allocation_shares <- function(animal,
 #'   \item{Non-excluded emission variables}{`allocation_col = 0` when `commodity_col == "Other"` (others unchanged).}
 #' }
 #'
+#'@details
+#'
+#' Emission variables listed in \code{excluded_vars} (e.g., emissions from manure
+#' burned as fuel or manure deposited on pasture) are treated as not attributable
+#' to edible livestock commodities under the chosen goal and scope. Consequently,
+#' these emissions are allocated entirely to the residual commodity category
+#' \code{"Other"} and are not distributed across milk, meat, fibre, work, or egg
+#' outputs.
+#' 
+#' The following methodological rules apply to emission variables listed in
+#' \code{excluded_vars}:
+#'
+#' \itemize{
+#'   \item \strong{Manure burned for fuel} — Emissions are considered outside the
+#'   life cycle assessment system boundaries under the defined goal and scope and
+#'   are therefore not attributed to edible livestock commodities. A cut-off
+#'   approach is applied, consistent with the IDF (2022) standard and LEAP guidelines (LEAP 2016a, 2016b, 2016c).
+#'   
+#'   \item \strong{Manure deposited on pasture or grassland} — Emissions are not
+#'   allocated to edible livestock commodities in order to avoid double counting.
+#'   When upstream feed production is included in the inventory, emission factors of feed items
+#'   already account for this source.
+#' }
+#'
+#' @references 
+#'
+#' IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+#' Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+#'
+#' FAO. 2016a. Environmental performance of large ruminant supply chains:
+#' Guidelines for assessment. Livestock Environmental Assessment and Performance
+#' (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+#' supply chains: Guidelines for assessment. Livestock Environmental Assessment
+#' and Performance (LEAP) Partnership. FAO, Rome, Italy.
+#'
+#' FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+#' chains: Guidelines for assessment. Livestock Environmental Assessment and
+#' Performance (LEAP) Partnership. FAO, Rome, Italy.
+#' 
 #' @export
 
 assign_allocation_to_emissions <- function(allocation_herd_long,

--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -2,12 +2,12 @@
 #'
 #' Converts fat- and protein-corrected milk output into the megajoule demand used in the allocation workflow.
 #' The formula calculates energy density based on standard milk composition and multiplies by production.
-#'
+#' 
 #' @param milk_fpcm_output Numeric scalar. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period). Default fat and protein content=0.04 and 0.033.
 #' @param standard_protein Numeric scalar. Reference protein content (g per 100 g milk).
 #' @param standard_fat Numeric scalar. Reference fat content (g per 100 g milk).
 #' @param standard_lactose Numeric scalar. Reference lactose content (g per 100 g milk).
-#'
+#' 
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export
 calc_energy_allocation_milk <- function(
@@ -36,7 +36,7 @@ calc_energy_allocation_milk <- function(
 }
 
 #' Meat Energy Requirement for Allocation
-#'
+#' 
 #' Applies species- and cohort-specific equations to compute the megajoules required to produce meat output.
 #' The calculation follows species-specific formulas to determine energy per kg liveweight, then multiplies by output.
 #'
@@ -45,7 +45,7 @@ calc_energy_allocation_milk <- function(
 #' @param slaughter_liveweight Numeric scalar. Slaughter liveweight (kg).
 #' @param birth_liveweight Numeric scalar. Birthweight (kg).
 #' @param output_meat_production_liveweight Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).
-#'
+#' 
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export
 calc_energy_allocation_meat <- function(
@@ -53,11 +53,12 @@ calc_energy_allocation_meat <- function(
     cohort_code,
     slaughter_liveweight,
     birth_liveweight,
-    output_meat_production_liveweight
+    output_meat_production_liveweight,
+    ratio_ne_to_me
 ) {
   validate_allocation_meat_inputs(
     animal, cohort_code,
-    slaughter_liveweight, birth_liveweight, output_meat_production_liveweight
+    slaughter_liveweight, birth_liveweight, output_meat_production_liveweight, ratio_ne_to_me
   )
 
   # Default fallback
@@ -84,8 +85,8 @@ calc_energy_allocation_meat <- function(
     }
 
   } else if (animal == "CML") {
-    # Camelids: simple linear formula
-    specific_energy_meat <- (41.8 * (slaughter_liveweight - birth_liveweight)) / slaughter_liveweight
+    
+    specific_energy_meat <- (41.8 * ratio_ne_to_me * (slaughter_liveweight - birth_liveweight)) / slaughter_liveweight
 
   } else if (animal == "SHP") {
     # Sheep: coefficients vary by cohort (female vs male)
@@ -134,7 +135,7 @@ calc_energy_allocation_meat <- function(
 #' @param fibre_energy_requirement Numeric scalar. Fibre energy demand (MJ per head per day).
 #' @param ratio_ne_to_me Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).
 #' @param assessment_duration Numeric. Length of the assessment period (days)
-#'
+#' 
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export
 calc_energy_allocation_fibre <- function(
@@ -164,12 +165,12 @@ calc_energy_allocation_fibre <- function(
 #' Work Energy Requirement for Allocation
 #'
 #' Estimates energy expenditure on animal work for the assessment duration, adjusting camelid values when required.
-#'
+#' 
 #' @param animal Character scalar. Species code (e.g., "CML" for camelids).
 #' @param work_energy_requirement Numeric scalar. Work energy demand (MJ per head per day).
 #' @param ratio_ne_to_me Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).
 #' @param assessment_duration Numeric. Length of the assessment period (days)
-#'
+#' 
 #' @return Numeric scalar. Energy requirements in megajoules.
 #' @export
 calc_energy_allocation_work <- function(
@@ -229,7 +230,7 @@ aggregate_cohort_to_herd <- function(data_cohort, id_cols, vars_to_sum, cohort) 
 #'
 #' Computes allocation shares of energy required for meat, milk, fibre, work, and eggs
 #' based on total energy demand per output. 
-#'
+#' 
 #' @param animal Character vector of animal species codes (e.g., "CTL", "SHP", "PGS").
 #' @param energy_meat Numeric vector: Herd-level energy requirement for meat production (MJ).
 #' @param energy_milk Numeric vector: Herd-level energy requirement for milk production (MJ).

--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -471,10 +471,9 @@ calc_net_energy_growth <- function(
     }
     ret <- ((final_weight - initial_weight) * (a + 0.5 * b * (initial_weight + final_weight))) / duration
   } else if (animal == "PGS") {
-    prot_tissue_frac <- 0.65 # Protein tissue fraction
-    fat_adipose_tissue_frac <- 0.9 # Fat in adipose tissue fraction
+    prot_tissue_frac <- 0.65 
     if (cohort %in% c("FS", "FJ", "MS", "MJ")) {
-      cgro <- (prot_tissue_frac * 0.23 * 54) + ((1 - prot_tissue_frac) * fat_adipose_tissue_frac * 52.3)
+      cgro <- (prot_tissue_frac * 0.23 * 54) + ((1 - prot_tissue_frac) * 0.9 * 52.3)
       ret <- dwg * cgro
     } else {
       ret <- 0

--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -526,7 +526,7 @@ calc_net_energy_growth <- function(
 #' @param lact Numeric. Duration of the lactation period, defined as the number of days during which the animal is lactating (days).
 #' @param parturition_rate Numeric. Numeric. Average annual number of parturitions per female animal (fraction). At herd level, calculated as offspring delivered divided by the number of adult females.
 #' @param lambing_interval Numeric. Average time interval between two successive births (days)
-#' @param assessment_duration Numeric. Length of the assessment period (days)
+#' @param weaning_age Numeric. Average age of the juvenile animals at weaning (days)
 #'
 #' @return Numeric. Energy required for lactation. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #'
@@ -672,39 +672,39 @@ calc_net_energy_lactation <- function(
     lact,
     parturition_rate,
     lambing_interval,
-    assessment_duration
+    weaning_age
 ) {
   # Validate inputs
   validate_lactation_inputs(
     animal, cohort, milking_fraction, milk_yield, milk_fat,
     idle, gest, litsize, dr1, ckg, wkg, lact,
-    parturition_rate, lambing_interval, assessment_duration
+    parturition_rate, lambing_interval, weaning_age
   )
   if (animal %in% c("CTL", "BFL")) {
     if (cohort == "FA") {
-      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg)) / assessment_duration) *
+      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg) / weaning_age)) *
         (milk_fat * 100 * 0.40 + 1.47)
     } else {
       ret <- 0
     }
   } else if (animal %in% c("CML")) {
     if (cohort == "FA") {
-      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg)) / assessment_duration) * 4.063
+      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg) / weaning_age)) * 4.063
     } else {
       ret <- 0
     }
   } else if (animal %in% c("SHP")) {
     if (cohort == "FA") {
       # Includes effect of litter size and lambing interval
-      ret <- ((milk_yield * milking_fraction)  + (litsize * (assessment_duration * parturition_rate / lambing_interval) * 5 *
-                                                    (wkg - ckg)) / assessment_duration) * 4.6
+      ret <- ((milk_yield * milking_fraction)  + (litsize * (parturition_rate / lambing_interval) * 5 *
+                                                    (wkg - ckg) / weaning_age)) * 4.6
     } else {
       ret <- 0
     }
   } else if (animal %in% c("GTS")) {
     if (cohort == "FA") {
-      ret <- ((milk_yield * milking_fraction)  + (litsize * (assessment_duration * parturition_rate / lambing_interval) * 5 *
-                                                    (wkg - ckg)) / assessment_duration) * 3
+      ret <- ((milk_yield * milking_fraction)  + (litsize * (parturition_rate / lambing_interval) * 5 *
+                                                    (wkg - ckg) / weaning_age)) * 3
     } else {
       ret <- 0
     }

--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -1012,9 +1012,8 @@ calc_net_energy_fibre <- function(
 #' Calculate Energy for Pregnancy
 #'
 #' Computes the **energy requirement for pregnancy** (MJ/head/day) for pregnant
-#' females. This approach follows the IPCC Tier 2 partitioning framework, where
-#' pregnancy energy is expressed as a fraction of the energy required for
-#' maintenance and is applied only to **female cohorts**.
+#' females. This approach follows the IPCC Tier 2 partitioning framework and is applied
+#' only to **female cohorts**.
 #'
 #' @param animal Character. Code identifying the livestock species.
 #'   Supported values include:
@@ -1037,71 +1036,108 @@ calc_net_energy_fibre <- function(
 #'     \item \code{MJ}: juvenile males (from birth to weaning)
 #'   }
 #' @param nemain Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal in equilibrium such that body energy is neither gained nor lost. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
-#' @param parturition_rate Numeric. Numeric. Average annual number of parturitions per female animal (fraction).
-#' At herd level, calculated as offspring delivered divided by the number of adult females.
+#' @param parturition_rate Numeric. Average annual number of parturitions per female animal (#). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.
 #' @param litsize Numeric. Average number of offspring born per parturition (#). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.
 #' @param gest Numeric. Duration of pregnancy period (days).
+#' @param idle Numeric. Period during which the animal is not performing any productive physiological function such as pregnancy or lactation (days).
+#' @param lact Numeric. Duration of the lactation period, defined as the number of days during which the animal is lactating (days).
 #' @param duration Numeric. Amount of time that each animal spends in a specific cohort (days).
 #' @param offtake_rate Numeric. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).
 #'
 #' @return Numeric. Energy required for pregnancy for pregnant adult females (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #'
 #' @details
-#' Pregnancy energy is applied only to female cohorts and is scaled according to
-#' reproductive exposure during the cohort stage:
-#' \itemize{
-#'   \item For adult females (\code{FA}), pregnancy energy is proportional to
-#'     \code{parturition_rate}.
-#'   \item For replacement females (\code{FS}), pregnancy energy is applied only
-#'     to the fraction of animals that remain in the cohort, using
-#'     \code{(1 - offtake_rate)}, and is scaled to the time pregnant within the
-#'     cohort using \code{gest / duration}.
-#' }
+#' Pregnancy energy is calculated **only for female cohorts**
+#' (i.e., \code{FA} and \code{FS}) and represents the additional
+#' energy required to support gestation.
+#' 
+#' For \code{FA}, pregnancy energy requirements are adjusted to account
+#' for the proportion of time animals spend in gestation.
 #'
-#'Specifics by species:
+#' For \code{FS}, only a fraction of animals is assumed to be of reproductive age;
+#' pregnancy energy requirements are therefore scaled accordingly.
+#'
 #'
 #' \itemize{
-#'   \item
-#'   \strong{CTL and BFL} — IPCC (2006, 2019).
-#'   Pregnancy is approximated as 10\% of maintenance energy averaged over the year:
+#'   \item For \strong{CTL and BFL} — IPCC (2006, 2019):
+#'   
+#'   Pregnancy energy is approximated as 10% of maintenance energy.
 #'   \itemize{
 #'     \item \code{FA}:
-#'     \deqn{energy\_pregnancy = 0.10 \times nemain \times parturition\_rate}
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       0.10 \times nemain \times parturition\_rate \times \frac{gest}{365}
+#'       }
 #'     \item \code{FS}:
-#'     \deqn{energy\_pregnancy = 0.10 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       0.10 \times nemain \times \frac{gest}{duration}
+#'       \times (1 - offtake\_rate)
+#'       }
 #'   }
 #'
-#' \strong{CML} — (Wardeh, 2004)
+#'   \item For \strong{CML} — Wardeh (2004):
+#'   
+#'   Pregnancy energy is estimated as 12% of maintenance energy.
 #'   \itemize{
 #'     \item \code{FA}:
-#'     \deqn{energy\_pregnancy = 0.12 \times nemain \times parturition\_rate}
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       0.12 \times nemain \times parturition\_rate
+#'       }
 #'     \item \code{FS}:
-#'     \deqn{energy\_pregnancy = 0.12 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       0.12 \times nemain \times \frac{gest}{duration}
+#'       \times (1 - offtake\_rate)
+#'       }
 #'   }
 #'
-#' \strong{SHP and GTS} — IPCC (2006, 2019).
-#' Pregnancy is calculated as a litter-size dependent fraction of maintenance:
-#' \deqn{energy\_pregnancy = cpreg(litsize) \times nemain \times parturition\_rate}
+#'   \item For \strong{SHP and GTS} — IPCC (2006, 2019):
+#'   
+#'   Pregnancy energy is calculated as a litter-size–dependent fraction
+#'   of maintenance energy.
+#'   \itemize{
+#'     \item \code{FA}:
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       nemain \times cpreg \times parturition\_rate \times \frac{gest}{365}
+#'       }
 #'       where \eqn{cpreg} is defined as:
 #'       \itemize{
 #'         \item If \eqn{1 \le litsize \le 2}:
-#'     \deqn{cpreg = 0.077 \times (2 - litsize) + 0.126 \times (litsize - 1)}
-#'   \item If \eqn{litsize > 2}: \deqn{cpreg = 0.150}
+#'           \deqn{
+#'           cpreg = 0.077 \times (2 - litsize) + 0.126 \times (litsize - 1)
 #'           }
-#' For replacement females (\code{FS}), the implementation applies the single-birth
-#' coefficient scaled by pregnancy exposure:
-#' \deqn{energy\_pregnancy = 0.077 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
+#'         \item If \eqn{litsize > 2}:
+#'           \deqn{cpreg = 0.150}
+#'       }
+#'     \item \code{FS} - 
+#'       Pregnancy energy is calculated using the single-birth coefficient
+#'       and scaled to the proportion of reproductive individuals in the cohort.
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       0.077 \times nemain \times \frac{gest}{duration}
+#'       \times (1 - offtake\_rate)
+#'       }
+#'   }
+#'
+#'   \item For \strong{PGS} — NRC (1998):
 #'   
-#' \strong{PGS} — (NRC, 1998):
-#' Pregnancy energy is implemented as a litter-based daily requirement using a
-#' gestation coefficient (\eqn{cgest}, MJ piglet\eqn{^{-1}}):
 #'   \itemize{
 #'     \item \code{FA}:
-#'     \deqn{energy\_pregnancy = cgest \times litsize \times parturition\_rate}
+#'       \deqn{
+#'       energy\_pregnancy = cgest \times litsize \times \frac{gest}{lact + gest + idle}
+#'       }
 #'     \item \code{FS}:
-#'     \deqn{energy\_pregnancy = cgest \times litsize \times parturition\_rate \times (gest/duration) \times (1-offtake\_rate)}
+#'       \deqn{
+#'       energy\_pregnancy =
+#'       cgest \times litsize \times \frac{gest}{duration}
+#'       \times (1 - offtake\_rate)
+#'       }
+#'   The default value for the gestation coefficient is
+#'   \eqn{cgest = 0.14985} MJ piglet\eqn{^{-1}}.
 #'   }
-#' with default \eqn{cgest = 0.14985} MJ piglet\eqn{^{-1}}.
 #' }
 #'
 #' @references
@@ -1127,6 +1163,8 @@ calc_net_energy_pregnancy <- function(
     parturition_rate,
     litsize,
     gest,
+    idle,
+    lact,
     duration,
     offtake_rate
 ) {
@@ -1143,11 +1181,11 @@ calc_net_energy_pregnancy <- function(
   # Validate inputs
   validate_pregnancy_inputs(
     animal, cohort, nemain, parturition_rate,
-    litsize, gest, duration, offtake_rate
+    litsize, gest, idle, lact, duration, offtake_rate
   )
   if (animal %in% c("CTL", "BFL")) {
     if (cohort == "FA") {
-      ret <- (nemain * 0.1 * parturition_rate)
+      ret <- (nemain * 0.1 * parturition_rate * gest / 365)
     } else if (cohort == "FS") {
       ret <- (nemain * 0.1) * (gest/duration) * (1 - offtake_rate)
     } else {
@@ -1170,21 +1208,21 @@ calc_net_energy_pregnancy <- function(
       } else if (litsize > 2) {
         cpreg <- 0.150
       }
-      ret <- nemain * cpreg * parturition_rate
+      ret <- nemain * cpreg * parturition_rate * gest / 365
     } else if (cohort == "FS") {
-      # 5 months pregnancy assumed
       ret <- nemain * 0.077 * (gest/duration) * (1 - offtake_rate)
     } else {
       ret <- 0
     }
   } else if (animal == "PGS") {
-    cgest <- 0.14985 # GLEAM coefficient for pigs
+    cgest <- 0.14985 
+    
     if (cohort == "FA") {
-      ret <- cgest * litsize * parturition_rate
+      ret <- cgest * litsize * gest / (idle + gest + lact)
 
     } else if (cohort == "FS") {
 
-      ret <- cgest * litsize * (gest / duration) * parturition_rate * (1 - offtake_rate)
+      ret <- cgest * litsize * (gest / duration) * (1 - offtake_rate)
 
     } else {
       ret <- 0

--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -524,9 +524,7 @@ calc_net_energy_growth <- function(
 #' @param ckg Numeric. Live body weight of the animal at birth (kg).
 #' @param wkg Numeric. Live body weight of the animal at weaning (kg).
 #' @param lact Numeric. Duration of the lactation period, defined as the number of days during which the animal is lactating (days).
-#' @param parturition_rate Numeric. Numeric. Average annual number of parturitions per female animal (fraction). At herd level, calculated as offspring delivered divided by the number of adult females.
-#' @param lambing_interval Numeric. Average time interval between two successive births (days)
-#' @param weaning_age Numeric. Average age of the juvenile animals at weaning (days)
+#' @param parturition_rate Numeric. Average annual number of parturitions per female animal (#). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.
 #'
 #' @return Numeric. Energy required for lactation. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #'
@@ -539,30 +537,33 @@ calc_net_energy_growth <- function(
 #' **quantity of milk produced** and a **species-specific energy cost per unit
 #' of milk**.
 #'
-#'\itemize{\strong{For CTL, BFL, CML, SHP and GTS}:
+#'\strong{For CTL, BFL, CML, SHP and GTS}:
+#'
 #' Total milk production includes:
 #' \itemize{
 #'   \item milk extracted for human consumption (\code{milk_yield})
-#'   \item milk consumed directly by offspring (\code{milk_from_offspring})
-#'     when milk yield is not directly observed (e.g., suckling systems).
+#'   \item milk consumed directly by offspring (\code{milk_for_offspring})
 #' }
 #'
 #' Lactation energy requirements are applied **only to adult females** and are
-#' scaled by the proportion of animals that are lactating within the cohort
-#' (\code{milking_fraction}).
+#' scaled by the proportion of milked (\code{milking_fraction}) or lactating 
+#' (\code{parturition_rate}) animals within the cohort.
+#' 
 #'
 #' In general form, lactation energy is computed as:
 #'
 #' \deqn{
 #' energy\_lactation =
-#' (milk\_yield + milk\_from\_offspring)
+#' (milk\_yield \times milking\_fraction + milk\_for\_offspring)
 #' \times energy\_milk
-#' \times milking\_fraction
+#' 
 #' }
 #'
-#' where \code{energy_milk} is a species-specific coefficient representing the
-#' net energy cost of producing one kilogram of milk (MJ kg\eqn{^{-1}}).
-#'
+#' where: 
+#' 
+#' \code{energy_milk} is a species-specific coefficient representing the
+#' net energy cost of producing one kilogram of milk (MJ kg\eqn{^{-1}})
+#' 
 #' Species-specific values of \code{energy_milk} are:
 #' \itemize{
 #'   \item \code{CTL}, \code{BFL}: estimated as a function of milk fat content,
@@ -570,35 +571,28 @@ calc_net_energy_growth <- function(
 #'   \item \code{CML}: 4.063 (Wardeh, 2004),
 #'   \item \code{SHP}: 4.6 (AFRC, 1993; AFRC, 1995),
 #'   \item \code{GTS}: 3.0 (AFRC, 1998).
-#' }
-#'
-#' When milk yield is not directly observed the amount of milk required to rear offspring
-#' is aproximated at **5 kilograms of milk per
-#' kilogram of live-weight gain to weaning**:
-#'
+#'   }
+#' 
+#' \code{milk_for_offspring} is the daily amount of milk required to rear offspring across the year (kg day\eqn{^{-1}}).
+#' It is calculated assuming that **5 kg of milk are required for each kilogram of live-weight gain up to weaning**, using the equation below.
+#' 
 #' \deqn{
-#' milk\_from\_offspring =
+#' milk\_for\_offspring =
 #' \frac{parturition\_rate \times 5 \times (wkg - ckg)}
-#' {assessment\_duration} \code(AFRC, 1990)
+#' {365} \code(AFRC, 1990)
 #' }
-#' }
+
+#' 
+#' For \code{SHP} and \code{GTS}, \code{milk_for_offspring} also accounts for
+#' the average number of offspring per birth by multiplying by \code{litsize}.
+#' 
 #'
-#' \itemize{\strong{For PGS} — NRC (1998).
+#' \strong{For PGS} — NRC (1998):
 #'
-#' For pigs, lactation energy is implemented as a **per-litter energy requirement**
-#' adjusted to the fraction of the reproductive cycle spent in lactation.
-#'
-#' The adjustment factor is defined as:
-#'
-#' \deqn{
-#' cadj = \frac{lact}{idle + gest + lact}
-#' }
-#'
-#' where \eqn{lact}, \eqn{idle}, and \eqn{gest} represent the durations (days)
-#' of lactation, non-productive (idle), and gestation phases, respectively.
-#'
-#' Lactation energy per sow per day is calculated as:
-#'
+#' For pigs, lactation energy accounts only for the milk consumed directly by offspring (\code{milk_for_offspring})
+#' adjusted by the fraction of the reproductive cycle spent in lactation (\code{cadj}),
+#' and is calculated as follows:
+#' 
 #' \deqn{
 #' energy\_lactation =
 #' litsize \times (1 - 0.5 \times dr1)
@@ -608,7 +602,7 @@ calc_net_energy_growth <- function(
 #' \right)
 #' \times cadj
 #' }
-#'
+#' 
 #' where:
 #' \itemize{
 #'   \item \eqn{0.02059} is the coefficient for lactation energy requirement
@@ -620,8 +614,12 @@ calc_net_energy_growth <- function(
 #'   \item \code{litsize} is litter size,
 #'   \item \code{dr1} is the proportion of stillborn piglets,
 #'   \item \eqn{wkg} and \eqn{ckg} are live weights at weaning and at birth,
-#'     respectively (kg).
-#' }
+#'     respectively (kg),
+#'    \item \eqn{cadj} is the fraction of the reproductive cycle spent in lactation calculated as
+#'    
+#'    \deqn{
+#'    cadj = \frac{lact}{idle + gest + lact}
+#'    }
 #' }
 #'
 #' @references
@@ -670,41 +668,39 @@ calc_net_energy_lactation <- function(
     ckg,
     wkg,
     lact,
-    parturition_rate,
-    lambing_interval,
-    weaning_age
+    parturition_rate
 ) {
   # Validate inputs
   validate_lactation_inputs(
     animal, cohort, milking_fraction, milk_yield, milk_fat,
     idle, gest, litsize, dr1, ckg, wkg, lact,
-    parturition_rate, lambing_interval, weaning_age
+    parturition_rate
   )
   if (animal %in% c("CTL", "BFL")) {
     if (cohort == "FA") {
-      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg) / weaning_age)) *
+      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg) / 365)) *
         (milk_fat * 100 * 0.40 + 1.47)
     } else {
       ret <- 0
     }
   } else if (animal %in% c("CML")) {
     if (cohort == "FA") {
-      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg) / weaning_age)) * 4.063
+      ret <- ((milk_yield * milking_fraction) + (parturition_rate * 5 * (wkg - ckg) / 365)) * 4.063
     } else {
       ret <- 0
     }
   } else if (animal %in% c("SHP")) {
     if (cohort == "FA") {
       # Includes effect of litter size and lambing interval
-      ret <- ((milk_yield * milking_fraction)  + (litsize * (parturition_rate / lambing_interval) * 5 *
-                                                    (wkg - ckg) / weaning_age)) * 4.6
+      ret <- ((milk_yield * milking_fraction)  + (litsize * parturition_rate * 5 *
+                                                    (wkg - ckg) / 365)) * 4.6
     } else {
       ret <- 0
     }
   } else if (animal %in% c("GTS")) {
     if (cohort == "FA") {
-      ret <- ((milk_yield * milking_fraction)  + (litsize * (parturition_rate / lambing_interval) * 5 *
-                                                    (wkg - ckg) / weaning_age)) * 3
+      ret <- ((milk_yield * milking_fraction)  + (litsize * parturition_rate * 5 *
+                                                    (wkg - ckg) / 365)) * 3
     } else {
       ret <- 0
     }
@@ -1050,7 +1046,7 @@ calc_net_energy_fibre <- function(
 #'
 #' @return Numeric. Energy required for pregnancy for pregnant adult females (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #'
-#'@details
+#' @details
 #' Pregnancy energy is applied only to female cohorts and is scaled according to
 #' reproductive exposure during the cohort stage:
 #' \itemize{
@@ -1069,42 +1065,42 @@ calc_net_energy_fibre <- function(
 #'   \strong{CTL and BFL} — IPCC (2006, 2019).
 #'   Pregnancy is approximated as 10\% of maintenance energy averaged over the year:
 #'   \itemize{
-#'   \item \code{FA}:
+#'     \item \code{FA}:
 #'     \deqn{energy\_pregnancy = 0.10 \times nemain \times parturition\_rate}
-#'   \item \code{FS}:
+#'     \item \code{FS}:
 #'     \deqn{energy\_pregnancy = 0.10 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
-#' }
+#'   }
 #'
 #' \strong{CML} — (Wardeh, 2004)
-#' \itemize{
-#'   \item \code{FA}:
+#'   \itemize{
+#'     \item \code{FA}:
 #'     \deqn{energy\_pregnancy = 0.12 \times nemain \times parturition\_rate}
-#'   \item \code{FS}:
+#'     \item \code{FS}:
 #'     \deqn{energy\_pregnancy = 0.12 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
-#' }
+#'   }
 #'
 #' \strong{SHP and GTS} — IPCC (2006, 2019).
 #' Pregnancy is calculated as a litter-size dependent fraction of maintenance:
 #' \deqn{energy\_pregnancy = cpreg(litsize) \times nemain \times parturition\_rate}
-#' where \eqn{cpreg} is defined as:
-#' \itemize{
-#'   \item If \eqn{1 \le litsize \le 2}:
+#'       where \eqn{cpreg} is defined as:
+#'       \itemize{
+#'         \item If \eqn{1 \le litsize \le 2}:
 #'     \deqn{cpreg = 0.077 \times (2 - litsize) + 0.126 \times (litsize - 1)}
 #'   \item If \eqn{litsize > 2}: \deqn{cpreg = 0.150}
-#' }
+#'           }
 #' For replacement females (\code{FS}), the implementation applies the single-birth
 #' coefficient scaled by pregnancy exposure:
 #' \deqn{energy\_pregnancy = 0.077 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
-#'
+#'   
 #' \strong{PGS} — (NRC, 1998):
 #' Pregnancy energy is implemented as a litter-based daily requirement using a
 #' gestation coefficient (\eqn{cgest}, MJ piglet\eqn{^{-1}}):
-#' \itemize{
-#'   \item \code{FA}:
+#'   \itemize{
+#'     \item \code{FA}:
 #'     \deqn{energy\_pregnancy = cgest \times litsize \times parturition\_rate}
-#'   \item \code{FS}:
+#'     \item \code{FS}:
 #'     \deqn{energy\_pregnancy = cgest \times litsize \times parturition\_rate \times (gest/duration) \times (1-offtake\_rate)}
-#' }
+#'   }
 #' with default \eqn{cgest = 0.14985} MJ piglet\eqn{^{-1}}.
 #' }
 #'

--- a/R/production_cohort_core_model.R
+++ b/R/production_cohort_core_model.R
@@ -99,12 +99,11 @@ compute_fibre_output <- function(
 #' Produces liveweight, carcass weight, boneless meat, and meat protein using the
 #' sequential multipliers from the legacy implementation.
 #'
-#' @param offtake_number Numeric. Number of animals removed via offtake (head/year).
+#' @param offtake_number_assessment Numeric. Number of animals removed via offtake (head/year).
 #' @param slaughter_weight Numeric. Live weight at slaughter (kg).
 #' @param carcass_dressing_percentage Numeric. Dressing percentage applied to live weight (fraction).
 #' @param bone_free_meat_fraction Numeric. Share of carcass that becomes boneless meat (fraction).
 #' @param meat_protein Numeric. Protein fraction of boneless meat (kg protein per kg meat).
-#' @param assessment_duration Numeric. Length of the assessment period (days)
 #'
 #' @return Named list containing:
 #'   \item{output_meat_production_liveweight}{Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).}
@@ -113,7 +112,7 @@ compute_fibre_output <- function(
 #'   \item{output_meat_production_protein}{Numeric. Total meat protein (excluding bones, organs, and other by-products after dressing and bone removal) produced over the assessment period by cohort (kg protein/cohort/year).}
 #' @export
 compute_meat_outputs <- function(
-    offtake_number,
+    offtake_number_assessment,
     slaughter_weight,
     carcass_dressing_percentage,
     bone_free_meat_fraction,
@@ -121,7 +120,7 @@ compute_meat_outputs <- function(
     assessment_duration
 ) {
   validate_meat_outputs_inputs(
-    offtake_number = offtake_number,
+    offtake_number_assessment = offtake_number_assessment,
     slaughter_weight = slaughter_weight,
     carcass_dressing_percentage = carcass_dressing_percentage,
     bone_free_meat_fraction = bone_free_meat_fraction,
@@ -129,7 +128,7 @@ compute_meat_outputs <- function(
     assessment_duration = assessment_duration
   )
 
-  meat_production_liveweight <- offtake_number / 365 * assessment_duration * slaughter_weight
+  meat_production_liveweight <- offtake_number_assessment * slaughter_weight
   meat_production_carcassweight <- meat_production_liveweight * carcass_dressing_percentage
   meat_production_meat <- meat_production_carcassweight * bone_free_meat_fraction
   meat_production_protein <- meat_production_meat * meat_protein

--- a/R/production_cohort_core_model.R
+++ b/R/production_cohort_core_model.R
@@ -116,17 +116,19 @@ compute_meat_outputs <- function(
     slaughter_weight,
     carcass_dressing_percentage,
     bone_free_meat_fraction,
-    meat_protein
+    meat_protein,
+    assessment_duration
 ) {
   validate_meat_outputs_inputs(
     offtake_number = offtake_number,
     slaughter_weight = slaughter_weight,
     carcass_dressing_percentage = carcass_dressing_percentage,
     bone_free_meat_fraction = bone_free_meat_fraction,
-    meat_protein = meat_protein
+    meat_protein = meat_protein,
+    assessment_duration = assessment_duration
   )
 
-  meat_production_liveweight <- offtake_number * slaughter_weight
+  meat_production_liveweight <- offtake_number/365 * assessment_duration * slaughter_weight
   meat_production_carcassweight <- meat_production_liveweight * carcass_dressing_percentage
   meat_production_meat <- meat_production_carcassweight * bone_free_meat_fraction
   meat_production_protein <- meat_production_meat * meat_protein

--- a/R/production_cohort_core_model.R
+++ b/R/production_cohort_core_model.R
@@ -129,7 +129,7 @@ compute_meat_outputs <- function(
     assessment_duration = assessment_duration
   )
 
-  meat_production_liveweight <- offtake_number/365 * assessment_duration * slaughter_weight
+  meat_production_liveweight <- offtake_number / 365 * assessment_duration * slaughter_weight
   meat_production_carcassweight <- meat_production_liveweight * carcass_dressing_percentage
   meat_production_meat <- meat_production_carcassweight * bone_free_meat_fraction
   meat_production_protein <- meat_production_meat * meat_protein

--- a/R/production_cohort_core_model.R
+++ b/R/production_cohort_core_model.R
@@ -4,7 +4,7 @@
 #' the legacy treatment of standard lactose.
 #'
 #' @param milk_yield Numeric. Milk yield per head per day (kg/day).
-#' @param assessment_duration Numeric. Number of assessment days in the year used to annualise outputs.
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #' @param size Numeric. Herd cohort size (heads).
 #' @param milking_fraction Numeric. Share of the cohort that is milking during the assessment window.
 #' @param milk_protein Numeric. Milk protein fraction (kg protein per kg milk).
@@ -16,9 +16,9 @@
 #' @param standard_lactose Numeric. Reference lactose fraction used for FPCM energy.
 #'
 #' @return Named list containing:
-#'   \item{output_milk_mass_production}{Numeric. Milk production (kg/year).}
-#'   \item{output_milk_protein_production}{Numeric. Milk protein production (kg protein/year).}
-#'   \item{output_milk_fpcm_production}{Numeric. Fat-protein-corrected milk production (kg FPCM/year).}
+#'   \item{output_milk_mass_production}{Numeric. Total milk production produced over the assessment period (kg/herd/assessment period).}
+#'   \item{output_milk_protein_production}{Numeric. Total milk protein production produced over the assessment period (kg protein/herd/assessment period).}
+#'   \item{output_milk_fpcm_production}{Numeric. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/herd/assessment period). Default fat and protein content=0.04 and 0.033.}
 #' @export
 compute_milk_outputs <- function(
     milk_yield,
@@ -74,10 +74,10 @@ compute_milk_outputs <- function(
 #' Compute Fibre Production
 #'
 #' @param fibre_prod Numeric. Fibre yield per head per year (kg/head/year).
-#' @param assessment_duration Numeric. Number of assessment days used to annualise fibre output.
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #' @param size Numeric. Herd size (heads) for the cohort.
 #'
-#' @return Numeric. Fibre production per cohort (kg/year).
+#' @return Numeric. Total fibre produced over the assessment period  by cohort (kg /cohort/assessment period).
 #' @export
 compute_fibre_output <- function(
     fibre_prod,
@@ -104,12 +104,13 @@ compute_fibre_output <- function(
 #' @param carcass_dressing_percentage Numeric. Dressing percentage applied to live weight (fraction).
 #' @param bone_free_meat_fraction Numeric. Share of carcass that becomes boneless meat (fraction).
 #' @param meat_protein Numeric. Protein fraction of boneless meat (kg protein per kg meat).
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #'
 #' @return Named list containing:
-#'   \item{output_meat_production_liveweight}{Numeric. Meat production as live weight (kg/year).}
-#'   \item{output_meat_production_carcassweight}{Numeric. Meat production as carcass weight (kg/year).}
-#'   \item{output_meat_production_meat}{Numeric. Boneless meat production (kg/year).}
-#'   \item{output_meat_production_protein}{Numeric. Meat protein production (kg protein/year).}
+#'   \item{output_meat_production_liveweight}{Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).}
+#'   \item{output_meat_production_carcassweight}{Numeric. Total meat as carcass weight (excluding organs, and other by-products after dressing) produced over the assessment period by cohort, (kg/cohort/year).}
+#'   \item{output_meat_production_meat}{Numeric. Total bone-free-meat (excluding bones, organs, and other by-products after dressing and bone removal) produced over the assessment period by cohort, (kg/cohort/year)}
+#'   \item{output_meat_production_protein}{Numeric. Total meat protein (excluding bones, organs, and other by-products after dressing and bone removal) produced over the assessment period by cohort (kg protein/cohort/year).}
 #' @export
 compute_meat_outputs <- function(
     offtake_number,

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -92,7 +92,8 @@ run_allocation <- function(
     cohort_code = cohort,
     slaughter_liveweight = slaughterLW,
     birth_liveweight = ckg,
-    output_meat_production_liveweight = output_meat_production_liveweight
+    output_meat_production_liveweight = output_meat_production_liveweight,
+    ratio_ne_to_me = ratio_ne_me_camelids
   ), by = .I]
 
   # Fibre energy allocation: applies camelid conversion factor when needed

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -47,7 +47,7 @@ run_allocation <- function(
     standard_fat = 0.04,
     standard_lactose = 0.048,
     ratio_ne_me_camelids = 0.43,
-    assessment_duration = assessment_duration
+    assessment_duration = 365
 ) {
   # --- Input validation
   # Validate that input is a data.frame with at least one row

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -92,7 +92,7 @@ run_allocation <- function(
     cohort_code = cohort,
     slaughter_liveweight = slaughterLW,
     birth_liveweight = ckg,
-    meat_output_liveweight = output_meat_production_liveweight
+    output_meat_production_liveweight = output_meat_production_liveweight
   ), by = .I]
 
   # Fibre energy allocation: applies camelid conversion factor when needed

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -47,7 +47,7 @@ run_allocation <- function(
     standard_fat = 0.04,
     standard_lactose = 0.048,
     ratio_ne_me_camelids = 0.43,
-    assessment_duration_days = 365
+    assessment_duration = assessment_duration
 ) {
   # --- Input validation
   # Validate that input is a data.frame with at least one row

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -13,7 +13,7 @@
 #' @param standard_fat Numeric scalar for reference milk fat content (g per 100 g milk).
 #' @param standard_lactose Numeric scalar for reference milk lactose content (g per 100 g milk).
 #' @param ratio_ne_me_camelids Numeric scalar for the net-to-metabolizable energy conversion for camelids.
-#' @param assessment_duration_days Numeric scalar giving the assessment period in days.
+#' @param assessment_duration Numeric scalar. Length of the assessment period (days).
 #'
 #' @return A named list of three `data.table` objects:
 #'   * `cohort_allocation_inputs`: Cohort-level inputs to estimate allocation shares at herd-level.
@@ -100,7 +100,7 @@ run_allocation <- function(
     animal = Animal_short,
     fibre_energy_requirement = nefibre,
     ratio_ne_to_me = ratio_ne_me_camelids,
-    assessment_duration = assessment_duration_days
+    assessment_duration = assessment_duration
   ), by = .I]
 
   # Work energy allocation: applies camelid conversion factor when needed
@@ -108,7 +108,7 @@ run_allocation <- function(
     animal = Animal_short,
     work_energy_requirement = nework,
     ratio_ne_to_me = ratio_ne_me_camelids,
-    assessment_duration = assessment_duration_days
+    assessment_duration = assessment_duration
   ), by = .I]
 
   # Eggs energy allocation: placeholder (not currently implemented)

--- a/R/run_energy_requirements.R
+++ b/R/run_energy_requirements.R
@@ -129,6 +129,8 @@ run_energy_requirements <- function(data) {
     parturition_rate = parturition_rate,
     litsize = litsize,
     gest = gest,
+    idle = idle,
+    lact = lact,
     duration = duration,
     offtake_rate = offtake_rate
   ), by = .I]

--- a/R/run_energy_requirements.R
+++ b/R/run_energy_requirements.R
@@ -104,7 +104,7 @@ run_energy_requirements <- function(data) {
     lact = lact,
     parturition_rate = parturition_rate,
     lambing_interval = lambing_interval,
-    assessment_duration = 365
+    weaning_age = weaning_age
   ), by = .I]
 
   # 5. Work energy (MJ/day)

--- a/R/run_energy_requirements.R
+++ b/R/run_energy_requirements.R
@@ -102,9 +102,7 @@ run_energy_requirements <- function(data) {
     ckg = ckg,
     wkg = wkg,
     lact = lact,
-    parturition_rate = parturition_rate,
-    lambing_interval = lambing_interval,
-    weaning_age = weaning_age
+    parturition_rate = parturition_rate
   ), by = .I]
 
   # 5. Work energy (MJ/day)

--- a/R/run_production_cohort.R
+++ b/R/run_production_cohort.R
@@ -36,7 +36,7 @@
 run_production_cohort <- function(
     data,
     lactose_lookup,
-    assessment_duration = 365,
+    assessment_duration = assessment_duration,
     standard_lactose = 0.048
 ) {
   # --- Step 1: Validate inputs -------------------------------------------------

--- a/R/run_production_cohort.R
+++ b/R/run_production_cohort.R
@@ -126,7 +126,7 @@ run_production_cohort <- function(
   )
 
   data[ , (meat_output_cols) := compute_meat_outputs(
-    offtake_number = offtake_number,
+    offtake_number_assessment = offtake_number_assessment,
     slaughter_weight = slaughter_weight,
     carcass_dressing_percentage = carcass_dressing_percentage,
     bone_free_meat_fraction = bone_free_meat_fraction,

--- a/R/run_production_cohort.R
+++ b/R/run_production_cohort.R
@@ -35,7 +35,7 @@
 run_production_cohort <- function(
     data,
     lactose_lookup,
-    assessment_duration = assessment_duration,
+    assessment_duration = 365,
     standard_lactose = 0.048
 ) {
   # --- Step 1: Validate inputs -------------------------------------------------

--- a/R/run_production_cohort.R
+++ b/R/run_production_cohort.R
@@ -13,8 +13,7 @@
 #'   `animal`, `LPS_short`, and `HerdType_short`.
 #' @param lactose_lookup data.table. Lookup table mapping `Animal_short` to lactose percentage values
 #'   in column `Value`.
-#' @param assessment_duration Numeric. Number of assessment days used to annualise production outputs.
-#'   Defaults to `365`.
+#' @param assessment_duration Numeric. Length of the assessment period (days)
 #' @param standard_lactose Numeric. Reference lactose fraction used for FPCM energy calculations.
 #'   Defaults to `0.048` (reflecting IDF 2022 guidance).
 #'

--- a/R/validate_allocation_core_model.R
+++ b/R/validate_allocation_core_model.R
@@ -70,13 +70,16 @@ validate_allocation_meat_inputs <- function(
     cohort_code,
     slaughter_liveweight,
     birth_liveweight,
-    output_meat_production_liveweight
+    output_meat_production_liveweight,
+    ratio_ne_to_me
 ) {
   validate_scalar_character(animal, "animal")
   validate_scalar_character(cohort_code, "cohort_code")
   validate_scalar_numeric(slaughter_liveweight, "slaughter_liveweight")
   validate_scalar_numeric(birth_liveweight, "birth_liveweight")
   validate_scalar_numeric(output_meat_production_liveweight, "output_meat_production_liveweight")
+  validate_scalar_numeric(ratio_ne_to_me, "ratio_ne_to_me")
+  
 
   # Validate animal species
   # Note: Allocation module uses these specific species codes
@@ -99,6 +102,9 @@ validate_allocation_meat_inputs <- function(
   # Basic bounds: weights should be non-negative and reasonable
   if (slaughter_liveweight < 0 || slaughter_liveweight > 2000) {
     cli::cli_abort("{.arg slaughter_liveweight} must be between 0 and 2000 kg.")
+  }
+  if (ratio_ne_to_me < 0 || ratio_ne_to_me > 1) {
+    cli::cli_abort("{.arg ratio_ne_to_me} must be between 0 and 1.")
   }
   if (birth_liveweight < 0 || birth_liveweight > 200) {
     cli::cli_abort("{.arg birth_liveweight} must be between 0 and 200 kg.")

--- a/R/validate_allocation_core_model.R
+++ b/R/validate_allocation_core_model.R
@@ -62,7 +62,7 @@ validate_allocation_milk_inputs <- function(
 #' @param cohort_code Character scalar. Cohort identifier (e.g., "FA", "FS", "FJ", "MA", "MS", "MJ").
 #' @param slaughter_liveweight Numeric scalar. Slaughter liveweight (kg).
 #' @param birth_liveweight Numeric scalar. Birthweight (kg).
-#' @param meat_output_liveweight Numeric scalar. Liveweight meat output (kg).
+#' @param output_meat_production_liveweight Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).
 #'
 #' @noRd
 validate_allocation_meat_inputs <- function(
@@ -70,13 +70,13 @@ validate_allocation_meat_inputs <- function(
     cohort_code,
     slaughter_liveweight,
     birth_liveweight,
-    meat_output_liveweight
+    output_meat_production_liveweight
 ) {
   validate_scalar_character(animal, "animal")
   validate_scalar_character(cohort_code, "cohort_code")
   validate_scalar_numeric(slaughter_liveweight, "slaughter_liveweight")
   validate_scalar_numeric(birth_liveweight, "birth_liveweight")
-  validate_scalar_numeric(meat_output_liveweight, "meat_output_liveweight")
+  validate_scalar_numeric(output_meat_production_liveweight, "output_meat_production_liveweight")
 
   # Validate animal species
   # Note: Allocation module uses these specific species codes
@@ -103,8 +103,8 @@ validate_allocation_meat_inputs <- function(
   if (birth_liveweight < 0 || birth_liveweight > 200) {
     cli::cli_abort("{.arg birth_liveweight} must be between 0 and 200 kg.")
   }
-  if (meat_output_liveweight < 0) {
-    cli::cli_abort("{.arg meat_output_liveweight} must be non-negative.")
+  if (output_meat_production_liveweight < 0) {
+    cli::cli_abort("{.arg output_meat_production_liveweight} must be non-negative.")
   }
 }
 

--- a/R/validate_energy_requirements_core_model.R
+++ b/R/validate_energy_requirements_core_model.R
@@ -254,6 +254,8 @@ validate_pregnancy_inputs <- function(
     parturition_rate,
     litsize,
     gest,
+    idle,
+    lact,
     duration,
     offtake_rate
 ) {
@@ -274,7 +276,11 @@ validate_pregnancy_inputs <- function(
   if (animal == "PGS") {
     if (!is.na(litsize)) validate_positive_numeric(litsize, "litsize")
     if (!is.na(gest)) validate_scalar_numeric(gest, "gest")
+    if (!is.na(gest)) validate_scalar_numeric(idle, "idle")
+    if (!is.na(gest)) validate_scalar_numeric(lact, "lact")
   }
+  
+  
 
   if (animal %in% c("SHP", "GTS")) {
     if (!is.na(litsize)) validate_positive_numeric(litsize, "litsize")

--- a/R/validate_energy_requirements_core_model.R
+++ b/R/validate_energy_requirements_core_model.R
@@ -160,9 +160,7 @@ validate_lactation_inputs <- function(
     ckg,
     wkg,
     lact,
-    parturition_rate,
-    lambing_interval,
-    weaning_age
+    parturition_rate
 ) {
   validate_animal_species(animal)
   validate_cohort_code(cohort)
@@ -170,8 +168,6 @@ validate_lactation_inputs <- function(
   validate_scalar_numeric(milk_yield, "milk_yield")
   validate_scalar_numeric(milk_fat, "milk_fat")
   validate_positive_numeric(parturition_rate, "parturition_rate")
-  validate_positive_numeric(weaning_age, "weaning_age")
-  
   validate_fraction(milking_fraction, "milking_fraction")
   validate_fraction(milk_fat, "milk_fat")
 
@@ -197,13 +193,6 @@ validate_lactation_inputs <- function(
     if (!is.na(litsize)) validate_positive_numeric(litsize, "litsize")
     if (!is.na(ckg)) validate_positive_numeric(ckg, "ckg")
     if (!is.na(wkg)) validate_positive_numeric(wkg, "wkg")
-    if (!is.na(lambing_interval)) validate_positive_numeric(lambing_interval, "lambing_interval")
-    
-    if (lambing_interval < 200) {
-      cli::cli_warn(
-        "{.field lambing_interval} is below 200 days. This may indicate an unrealistic input."
-      )
-    }
     
     }
 

--- a/R/validate_energy_requirements_core_model.R
+++ b/R/validate_energy_requirements_core_model.R
@@ -162,7 +162,7 @@ validate_lactation_inputs <- function(
     lact,
     parturition_rate,
     lambing_interval,
-    assessment_duration
+    weaning_age
 ) {
   validate_animal_species(animal)
   validate_cohort_code(cohort)
@@ -170,7 +170,7 @@ validate_lactation_inputs <- function(
   validate_scalar_numeric(milk_yield, "milk_yield")
   validate_scalar_numeric(milk_fat, "milk_fat")
   validate_positive_numeric(parturition_rate, "parturition_rate")
-  validate_positive_numeric(parturition_rate, "assessment_duration")
+  validate_positive_numeric(weaning_age, "weaning_age")
   
   validate_fraction(milking_fraction, "milking_fraction")
   validate_fraction(milk_fat, "milk_fat")

--- a/R/validate_production_cohort_core_model.R
+++ b/R/validate_production_cohort_core_model.R
@@ -93,7 +93,8 @@ validate_meat_outputs_inputs <- function(
     slaughter_weight,
     carcass_dressing_percentage,
     bone_free_meat_fraction,
-    meat_protein
+    meat_protein,
+    assessment_duration
 ) {
   # Scalar numeric inputs
   validate_scalar_numeric(offtake_number, "offtake_number")

--- a/R/validate_production_cohort_core_model.R
+++ b/R/validate_production_cohort_core_model.R
@@ -89,7 +89,7 @@ validate_fibre_output_inputs <- function(
 #'
 #' @noRd
 validate_meat_outputs_inputs <- function(
-    offtake_number,
+    offtake_number_assessment,
     slaughter_weight,
     carcass_dressing_percentage,
     bone_free_meat_fraction,
@@ -97,15 +97,15 @@ validate_meat_outputs_inputs <- function(
     assessment_duration
 ) {
   # Scalar numeric inputs
-  validate_scalar_numeric(offtake_number, "offtake_number")
+  validate_scalar_numeric(offtake_number_assessment, "offtake_number_assessment")
   validate_scalar_numeric(slaughter_weight, "slaughter_weight")
   validate_scalar_numeric(carcass_dressing_percentage, "carcass_dressing_percentage")
   validate_scalar_numeric(bone_free_meat_fraction, "bone_free_meat_fraction")
   validate_scalar_numeric(meat_protein, "meat_protein")
 
   # Non-negative checks
-  if (offtake_number < 0) {
-    cli::cli_abort("{.arg offtake_number} must be non-negative.")
+  if (offtake_number_assessment < 0) {
+    cli::cli_abort("{.arg offtake_number_assessment} must be non-negative.")
   }
   if (slaughter_weight < 0) {
     cli::cli_abort("{.arg slaughter_weight} must be non-negative.")

--- a/man/aggregate_cohort_to_herd.Rd
+++ b/man/aggregate_cohort_to_herd.Rd
@@ -7,18 +7,18 @@
 aggregate_cohort_to_herd(data_cohort, id_cols, vars_to_sum, cohort)
 }
 \arguments{
-\item{id_cols}{Character vector of ID variables (e.g., Animal_short, LPS_short, HerdType_short).@Yassine: this should be revised. Record_id should be used.}
+\item{id_cols}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd.}
 
-\item{vars_to_sum}{Character vector of column names to be summed during aggregation.}
+\item{vars_to_sum}{Character vector. Names of numeric cohort-level variables to be summed across cohorts to produce herd-level totals (e.g., energy_allocation_meat, energy_allocation_milk, energy_allocation_fibre, energy_allocation_work, energy_allocation_eggs)}
 
-\item{cohort}{Character. Cohort code (e.g., "FJ", "MJ", "FS", "MS", "FA", "MA").}
+\item{cohort}{Character. Name of the column identifying the sex–age cohort (e.g. FJ, FA, MJ, etc.).}
 
-\item{data}{A \code{data.table} containing cohort-level data.}
+\item{data}{A \code{data.table} at cohort-level containing energy allocation variables and herd identifiers. Each row corresponds to a single sex–age cohort within a herd.}
 }
 \value{
-A \code{data.table} with summed values at the herd level.
+A \code{data.table} at herd scale, in which selected cohort-level variables have been summed across all cohorts belonging to the same herd, as defined by id_herd.
 }
 \description{
 This function aggregates a dataset from cohort level to herd level by summing
-specified variables over the defined ID columns.
+specified variables over the defined 'id' columns.
 }

--- a/man/assign_allocation_to_emissions.Rd
+++ b/man/assign_allocation_to_emissions.Rd
@@ -16,15 +16,15 @@ assign_allocation_to_emissions(
 \arguments{
 \item{allocation_herd_long}{A \code{data.table} containing a commodity column (levels=Eggs, Milk, Meat, Work, Fibre..) and an allocation share column.}
 
-\item{emissions_vars}{Character vector of names of emission variable sources to assign to different emission shares (e.g. \code{"ch4_enteric"}, \code{"direct_n2o_manure_other"}).}
+\item{emissions_vars}{Character vector. Names of emission variables to which allocation should be applied (e.g., "ch4_enteric","ch4_manure_pasture","ch4_manure_burned","ch4_manure_other",         "direct_n2o_manure_pasture","direct_n2o_manure_burned","direct_n2o_manure_other", "indirect_n2o_manure_burned","indirect_n2o_manure_pasture","indirect_n2o_manure_other")}
 
-\item{commodities}{Character vector of commodity names to create combinations for. (e.g., "Other","Milk","Meat","Fibre","Work","Eggs")}
+\item{commodities}{Character vector. List of commodity categories to which emissions may be allocated. List=c("Other","Milk","Meat","Fibre","Work","Eggs")}
 
-\item{excluded_vars}{Character vector of emission sources that must be allocated fully to \code{"Other"}.}
+\item{excluded_vars}{Character vector. Emission variables that should not be allocated across commodities, even if they appear in emissions_vars ( e.g., "ch4_manure_pasture","ch4_manure_burned"..)}
 
-\item{commodity_col}{Character scalar. Name of the commodity column in the dataset \code{allocation_herd_long} (e.g. \code{"commodity_name"}).}
+\item{commodity_col}{Character. Name of the column in \code{allocation_herd_long} identifying the commodity category.}
 
-\item{allocation_col}{Character scalar. Name of the allocation share column in the dataset \code{allocation_herd_long} (e.g. \code{"allocation_share"}).}
+\item{allocation_col}{Character. Name of the column in \code{allocation_herd_long} containing the allocation share to be applied.}
 }
 \value{
 A \code{data.table} equal to \code{allocation_herd_long} expanded over all \code{emissions_vars},
@@ -35,7 +35,51 @@ with enforced allocation rules:
 }
 }
 \description{
-Expands an allocation table so that each commodity is combined with each emission source.
+Assign Allocation Shares to Emission Variables by Commodity
+}
+\details{
 Then enforces the allocation of emissions from manure burned as fuel and deposited on pasture
 to be \strong{100\% to the commodity "Other"}.
+
+Emission variables listed in \code{excluded_vars} (e.g., emissions from manure
+burned as fuel or manure deposited on pasture) are treated as not attributable
+to edible livestock commodities under the chosen goal and scope. Consequently,
+these emissions are allocated entirely to the residual commodity category
+\code{"Other"} and are not distributed across milk, meat, fibre, work, or egg
+outputs.
+
+The following methodological rules apply to emission variables listed in
+\code{excluded_vars}:
+
+\itemize{
+\item \strong{Manure burned for fuel} — Emissions are considered outside the
+life cycle assessment system boundaries under the defined goal and scope and
+are therefore not attributed to edible livestock commodities. A cut-off
+approach is applied, consistent with the IDF (2022) standard and LEAP guidelines (LEAP 2016a, 2016b, 2016c).
+
+\item \strong{Manure deposited on pasture or grassland} — Emissions are not
+allocated to edible livestock commodities in order to avoid double counting.
+When upstream feed production is included in the inventory, emission factors of feed items
+already account for this source.
+}
+}
+\section{This function operationalizes commodity-level allocation of emissions by combining each commodity with each emission source}{
+and applying predefined allocation rules (see details).
+}
+
+\references{
+IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+
+FAO. 2016a. Environmental performance of large ruminant supply chains:
+Guidelines for assessment. Livestock Environmental Assessment and Performance
+(LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+supply chains: Guidelines for assessment. Livestock Environmental Assessment
+and Performance (LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+chains: Guidelines for assessment. Livestock Environmental Assessment and
+Performance (LEAP) Partnership. FAO, Rome, Italy.
 }

--- a/man/calc_allocation_shares.Rd
+++ b/man/calc_allocation_shares.Rd
@@ -14,29 +14,92 @@ calc_allocation_shares(
 )
 }
 \arguments{
-\item{animal}{Character vector of animal species codes (e.g., "CTL", "SHP", "PGS").}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{energy_meat}{Numeric vector: Herd-level energy requirement for meat production (MJ).}
+\item{energy_meat}{Numeric. Energy required for total meat output by herd during
+the assessment period, equal to the energy needed to produce all live-weight gain to reach the target slaughter weight (MJ/herd/assessment period).}
 
-\item{energy_milk}{Numeric vector: Herd-level energy requirement for milk production (MJ).}
+\item{energy_milk}{Numeric. Energy required to produce total milk output by herd (MJ/herd/assessment period).}
 
-\item{energy_fibre}{Numeric vector: Herd-level energy requirement for fibre production (MJ).}
+\item{energy_fibre}{Numeric. Energy required to produce all fibre output by herd (MJ/herd/assessment period).}
 
-\item{energy_work}{Numeric vector: Herd-level energy requirement for work (MJ).}
+\item{energy_work}{Numeric vector. Energy required to provide all draught power (traction/work) by herd (MJ/herd/assessment period)}
 
-\item{energy_eggs}{Numeric vector: Herd-level energy requirement for eggs (MJ).}
+\item{energy_eggs}{Numeric vector: Energy required to produce eggs by the herd during the assessment period (MJ/herd/assessment period).}
 }
 \value{
 A named list of numeric vectors with same length as input, containing:
 \describe{
-\item{allocation_share_meat}{Proportion of total energy allocated to meat}
-\item{allocation_share_milk}{... to milk}
-\item{allocation_share_fibre}{... to fibre}
-\item{allocation_share_work}{... to work}
-\item{allocation_share_eggs}{... to eggs}
+\item{allocation_share_meat}{Numeric. Allocation share assigned to meat (fraction).}
+\item{allocation_share_milk}{Numeric. Allocation share assigned to milk (fraction).}
+\item{allocation_share_fibre}{Numeric. Allocation share assigned to fibre (fraction).}
+\item{allocation_share_work}{Numeric. Allocation share assigned to work (fraction).}
+\item{allocation_share_eggs}{Numeric. Allocation share assigned to eggs (fraction).}
 }
 }
 \description{
-Computes allocation shares of energy required for meat, milk, fibre, work, and eggs
-based on total energy demand per output.
+Calculates biophysical allocation fractions for commodities (meat, milk, fibre, work,
+eggs) based on their total energy requirements.
+}
+\details{
+These fractions represent the proportions of total environmental burdens (e.g., GHG
+emissions) that will be allocated to each commodity in subsequent steps of the
+assessment.
+
+The biophysical approach follows the IDF Global Carbon Footprint Standard for the
+Dairy Sector (IDF, 2022), adapted from Thoma and Nemecek (2020), and is consistent
+with FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c). It aligns with
+ISO 14044:2006 (Section 4.3.4.2, Step 2) by using underlying physical (energy-based)
+relationships to assign shared inputs and outputs in multifunctional livestock
+production systems.
+
+In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+biophysical relationships may be used to assign shared inputs and outputs of a
+single production unit to individual products or sub-units. In livestock systems,
+this includes apportioning shared feed and energy use according to physiological
+energy requirements (e.g., net energy for lactation, growth..etc.). If the
+resulting process remains multifunctional, these energy terms may subsequently
+be used to derive allocation factors among co-products.
+
+This function calculates biophysical allocation
+fractions for commodities (meat, milk, fibre, work, eggs) for all species.
+
+\strong{Pig systems (\code{PGS}).} For pigs, allocation is not based on energy
+partitioning because pig production is treated as functionally single-output
+(edible meat). Consequently, 100\% of the allocation is assigned to the meat
+commodity (meat share = 1; all other commodity shares = 0), independent of the
+energy inputs.
+}
+\references{
+ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+
+IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+
+Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+Critical discussion of the IDF’s standard methodology. Proceedings of the
+12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+pp. 83–89, 13–16 October, Berlin, Germany.
+
+FAO. 2016a. Environmental performance of large ruminant supply chains:
+Guidelines for assessment. Livestock Environmental Assessment and Performance
+(LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+supply chains: Guidelines for assessment. Livestock Environmental Assessment
+and Performance (LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+chains: Guidelines for assessment. Livestock Environmental Assessment and
+Performance (LEAP) Partnership. FAO, Rome, Italy.
 }

--- a/man/calc_energy_allocation_fibre.Rd
+++ b/man/calc_energy_allocation_fibre.Rd
@@ -8,7 +8,7 @@ calc_energy_allocation_fibre(
   animal,
   fibre_energy_requirement,
   ratio_ne_to_me,
-  assessment_duration = 365
+  assessment_duration
 )
 }
 \arguments{

--- a/man/calc_energy_allocation_fibre.Rd
+++ b/man/calc_energy_allocation_fibre.Rd
@@ -12,17 +12,84 @@ calc_energy_allocation_fibre(
 )
 }
 \arguments{
-\item{animal}{Character scalar. Species code (e.g., "GTS", "SHP", "CML").}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{fibre_energy_requirement}{Numeric scalar. Fibre energy demand (MJ per head per day).}
+\item{fibre_energy_requirement}{Numeric. Energy required for the synthesis of fibre for SHP, GTS and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for SHP and GTS and as metabolizable energy for CML (MJ/head/day).}
 
-\item{ratio_ne_to_me}{Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).}
+\item{ratio_ne_to_me}{Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.}
 
-\item{assessment_duration}{Numeric. Length of the assessment period (days)}
+\item{assessment_duration}{Numeric. Length of the assessment period (days).}
 }
 \value{
-Numeric scalar. Energy requirements in megajoules.
+Numeric scalar. Energy required to produce all fibre output by cohort (MJ/cohort/assessment period).
+
+Non-zero values are expected only for fiber-producing species (CML, SHP, GTS) and assumed cohorts ("FA", "FS", "MA", "MS")
 }
 \description{
-Computes fibre energy demand over the assessment window, applying the camelid conversion factor when required.
+Calculates the net energy demand (MJ) associated with fibre production over the
+assessment period for fibre-producing species and cohorts.
+}
+\details{
+This function provides the fibre-related energy term used in a biophysical
+allocation framework to apportion emissions between milk and other co-products
+in multifunctional livestock production systems.
+
+The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+
+In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+biophysical relationships may be used to assign shared inputs and outputs of a
+single production unit to individual products or sub-units. In livestock systems,
+this includes apportioning shared feed and energy use according to physiological
+energy requirements (e.g., net energy for lactation, growth..etc.). If the
+resulting process remains multifunctional, these energy terms may subsequently
+be used to derive allocation factors among co-products.
+
+Total fibre-related energy over the assessment period is computed for
+fibre-producing species (\code{CML}, \code{SHP},
+\code{GTS}) and applicable cohorts (\code{"FA"}, \code{"FS"}, \code{"MA"},
+\code{"MS"}).
+
+The calculation is:
+
+\itemize{
+\item \code{energy_allocation_fibre = fibre_energy_requirement * assessment_duration}
+}
+
+where \code{fibre_energy_requirement} represents the daily energy requirement
+for fibre production (MJ/head/day) and is obtained from
+\code{\link[gleam]{calc_net_energy_fibre}}.
+}
+\references{
+ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+
+IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+
+Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+Critical discussion of the IDF’s standard methodology. Proceedings of the
+12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+pp. 83–89, 13–16 October, Berlin, Germany.
+
+FAO. 2016a. Environmental performance of large ruminant supply chains:
+Guidelines for assessment. Livestock Environmental Assessment and Performance
+(LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+supply chains: Guidelines for assessment. Livestock Environmental Assessment
+and Performance (LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+chains: Guidelines for assessment. Livestock Environmental Assessment and
+Performance (LEAP) Partnership. FAO, Rome, Italy.
 }

--- a/man/calc_energy_allocation_fibre.Rd
+++ b/man/calc_energy_allocation_fibre.Rd
@@ -18,7 +18,7 @@ calc_energy_allocation_fibre(
 
 \item{ratio_ne_to_me}{Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).}
 
-\item{assessment_duration}{Numeric scalar. Assessment duration (days).}
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 }
 \value{
 Numeric scalar. Energy requirements in megajoules.

--- a/man/calc_energy_allocation_meat.Rd
+++ b/man/calc_energy_allocation_meat.Rd
@@ -9,7 +9,7 @@ calc_energy_allocation_meat(
   cohort_code,
   slaughter_liveweight,
   birth_liveweight,
-  meat_output_liveweight
+  output_meat_production_liveweight
 )
 }
 \arguments{
@@ -21,7 +21,7 @@ calc_energy_allocation_meat(
 
 \item{birth_liveweight}{Numeric scalar. Birthweight (kg).}
 
-\item{meat_output_liveweight}{Numeric scalar. Liveweight meat output (kg).}
+\item{output_meat_production_liveweight}{Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).}
 }
 \value{
 Numeric scalar. Energy requirements in megajoules.

--- a/man/calc_energy_allocation_meat.Rd
+++ b/man/calc_energy_allocation_meat.Rd
@@ -9,24 +9,128 @@ calc_energy_allocation_meat(
   cohort_code,
   slaughter_liveweight,
   birth_liveweight,
-  output_meat_production_liveweight
+  output_meat_production_liveweight,
+  ratio_ne_to_me
 )
 }
 \arguments{
-\item{animal}{Character scalar. Species code (e.g., "CTL", "BFL", "CML", "SHP", "GTS", "PGS").}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{cohort_code}{Character scalar. Cohort identifier (e.g., "FA", "FS", "FJ", "MA", "MS", "MJ").}
+\item{cohort_code}{Character scalar.Sex- and age-specific cohort code describing the
+production stage of the animals. Supported values include:
+\itemize{
+\item \code{FA}: adult females (from age at first parturition)
+\item \code{FS}: sub-adult females (from weaning to age at first parturition)
+\item \code{FJ}: juvenile females (from birth to weaning)
+\item \code{MA}: adult males (from age at first breeding)
+\item \code{MS}: sub-adult males (from weaning to age at first breeding)
+\item \code{MJ}: juvenile males (from birth to weaning)
+}}
 
-\item{slaughter_liveweight}{Numeric scalar. Slaughter liveweight (kg).}
+\item{slaughter_liveweight}{Numeric scalar. Live weight at slaughter for animals removed from the cohort (kg).}
 
-\item{birth_liveweight}{Numeric scalar. Birthweight (kg).}
+\item{birth_liveweight}{Numeric scalar. Live weight of the animal at birth (kg).}
 
 \item{output_meat_production_liveweight}{Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).}
+
+\item{ratio_ne_to_me}{Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.}
 }
 \value{
-Numeric scalar. Energy requirements in megajoules.
+Numeric scalar. Energy required by a given sex–age cohort for total meat output by cohort during
+the assessment period, equal to the energy needed to produce all live-weight gain to reach the target slaughter weight (MJ/cohort/assessment period).
+
+Non-zero values are applicable to all species/cohorts where growth is modelled. For
+pigs (\code{PGS}), the function returns \code{NA} by design.
 }
 \description{
-Applies species- and cohort-specific equations to compute the megajoules required to produce meat output.
-The calculation follows species-specific formulas to determine energy per kg liveweight, then multiplies by output.
+Calculates the net energy demand (MJ) associated with meat production (expressed as
+liveweight output) over the assessment period for a given species and cohort.
+}
+\details{
+This function provides the meat-related energy term used in a biophysical
+allocation framework to apportion emissions between milk and other co-products
+in multifunctional livestock production systems.
+
+The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+
+In accordance with ISO 14044:2006
+(Section 4.3.4.2, Step 2), known processing or biophysical relationships may be
+used to assign shared inputs and outputs of a single production unit to
+individual products or sub-units. In livestock systems, this includes
+apportioning shared feed and energy use according to physiological energy
+requirements (e.g., net energy for lactation or growth). If the process
+remains multifunctional after such assignment, the resulting energy terms
+may be used to derive allocation factors among co-products.
+
+The objective of this function is to estimate the net
+energy required to produce the meat obtained during the assessment period.
+This is achieved by quantifying the physiological energy required for animals
+to grow from birth weight to slaughter weight for each species and cohort.
+
+Total energy required for meat production over the assessment period ((\code{specific_energy_meat}is then
+calculated as:
+
+\itemize{
+\item \code{energy_allocation_meat = specific_energy_meat * output_meat_production_liveweight}
+}
+
+where
+
+\code{output_meat_production_liveweight} is the average
+net energy required to produce one kilogram of liveweight gain, accounting
+for differences in growth efficiency, metabolic scaling, and sex-specific
+growth patterns (MJ/kg live weight)
+
+\code{specific_energy_meat} is the total liveweight of
+animals sold for meat during the assessment period, which is calculated with a specie-specific approach:
+
+\itemize{
+\item \strong{For (\code{CTL}, \code{BFL}, \code{CML},
+\code{SHP}, \code{GTS})}:
+
+Growth energy is calculated using species- and
+cohort-specific biophysical relationships adapted from established growth
+energy formulations (further details in \code{\link{?gleam::calc_net_energy_growth}}).
+
+\item \strong{For (\code{PGS})}:
+
+Growth energy is not calculated in this
+function and \code{NA} is returned. In downstream processing,
+\code{\link{calc_allocation_shares}} assigns 100\% of the allocation to the
+edible meat commodity for pig systems.
+}
+}
+\references{
+ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+
+IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+
+Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+Critical discussion of the IDF’s standard methodology. Proceedings of the
+12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+pp. 83–89, 13–16 October, Berlin, Germany.
+
+FAO. 2016a. Environmental performance of large ruminant supply chains:
+Guidelines for assessment. Livestock Environmental Assessment and Performance
+(LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+supply chains: Guidelines for assessment. Livestock Environmental Assessment
+and Performance (LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+chains: Guidelines for assessment. Livestock Environmental Assessment and
+Performance (LEAP) Partnership. FAO, Rome, Italy.
 }

--- a/man/calc_energy_allocation_milk.Rd
+++ b/man/calc_energy_allocation_milk.Rd
@@ -12,18 +12,68 @@ calc_energy_allocation_milk(
 )
 }
 \arguments{
-\item{milk_fpcm_output}{Numeric scalar. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period). Default fat and protein content=0.04 and 0.033.}
+\item{milk_fpcm_output}{Numeric scalar. Total fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period).
 
-\item{standard_protein}{Numeric scalar. Reference protein content (g per 100 g milk).}
+Default fat and protein content=0.04 and 0.033.}
 
-\item{standard_fat}{Numeric scalar. Reference fat content (g per 100 g milk).}
+\item{standard_protein}{Numeric. Standard protein content of milk, used to calculate Fat-protein-corrected milk (FPCM), (kg protein/kg milk).
 
-\item{standard_lactose}{Numeric scalar. Reference lactose content (g per 100 g milk).}
+Default used=0.033.}
+
+\item{standard_fat}{Numeric. Standard fat content of milk, used to calculate Fat-protein-corrected milk (FPCM), (kg fat/kg milk).
+
+Default used=0.04.}
+
+\item{standard_lactose}{Numeric. Standard lactose content of milk, used to calculate Fat-protein-corrected milk (FPCM) , (kg lactose/kg milk).
+
+Default used=0.048.}
 }
 \value{
-Numeric scalar. Energy requirements in megajoules.
+Numeric scalar. Energy required to produce total milk output by cohort (MJ/cohort/assessment period).
+
+Non-zero values are applicable only to milk-producing species and cohorts (species=CTL, BFL, CML, SHP, GTS; cohorts=AF).
+All other species–cohort combinations are assigned a value of 0.
 }
 \description{
-Converts fat- and protein-corrected milk output into the megajoule demand used in the allocation workflow.
-The formula calculates energy density based on standard milk composition and multiplies by production.
+Calculates the net energy demand (MJ) required to produce total fat-protein-corrected milk (FPCM) over the assessment period.
+}
+\details{
+This function provides the milk-related energy term used in a biophysical
+allocation framework to apportion emissions between milk and other co-products
+in multifunctional livestock production systems.
+
+The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+
+In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+biophysical relationships may be used to assign shared inputs and outputs of a
+single production unit to individual products or sub-units. In livestock systems,
+this includes apportioning shared feed and energy use according to physiological
+energy requirements (e.g., net energy for lactation, growth..etc.). If the
+resulting process remains multifunctional, these energy terms may subsequently
+be used to derive allocation factors among co-products.
+}
+\references{
+ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+
+IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+
+Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+Critical discussion of the IDF’s standard methodology. Proceedings of the
+12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+pp. 83–89, 13–16 October, Berlin, Germany.
+
+FAO. 2016a. Environmental performance of large ruminant supply chains:
+Guidelines for assessment. Livestock Environmental Assessment and Performance
+(LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+supply chains: Guidelines for assessment. Livestock Environmental Assessment
+and Performance (LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+chains: Guidelines for assessment. Livestock Environmental Assessment and
+Performance (LEAP) Partnership. FAO, Rome, Italy.
 }

--- a/man/calc_energy_allocation_milk.Rd
+++ b/man/calc_energy_allocation_milk.Rd
@@ -12,7 +12,7 @@ calc_energy_allocation_milk(
 )
 }
 \arguments{
-\item{milk_fpcm_output}{Numeric scalar. Fat- and protein-corrected milk production (kg).}
+\item{milk_fpcm_output}{Numeric scalar. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/assessment period). Default fat and protein content=0.04 and 0.033.}
 
 \item{standard_protein}{Numeric scalar. Reference protein content (g per 100 g milk).}
 

--- a/man/calc_energy_allocation_work.Rd
+++ b/man/calc_energy_allocation_work.Rd
@@ -18,7 +18,7 @@ calc_energy_allocation_work(
 
 \item{ratio_ne_to_me}{Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).}
 
-\item{assessment_duration}{Numeric scalar. Assessment duration (days).}
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 }
 \value{
 Numeric scalar. Energy requirements in megajoules.

--- a/man/calc_energy_allocation_work.Rd
+++ b/man/calc_energy_allocation_work.Rd
@@ -8,7 +8,7 @@ calc_energy_allocation_work(
   animal,
   work_energy_requirement,
   ratio_ne_to_me,
-  assessment_duration = 365
+  assessment_duration
 )
 }
 \arguments{

--- a/man/calc_energy_allocation_work.Rd
+++ b/man/calc_energy_allocation_work.Rd
@@ -12,17 +12,81 @@ calc_energy_allocation_work(
 )
 }
 \arguments{
-\item{animal}{Character scalar. Species code (e.g., "CML" for camelids).}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{work_energy_requirement}{Numeric scalar. Work energy demand (MJ per head per day).}
+\item{work_energy_requirement}{Numeric. Energy required for work, used to estimate the energy required for draught power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).}
 
-\item{ratio_ne_to_me}{Numeric scalar. Net-to-metabolizable energy conversion ratio (used for camelids).}
+\item{ratio_ne_to_me}{Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.}
 
-\item{assessment_duration}{Numeric. Length of the assessment period (days)}
+\item{assessment_duration}{Numeric. Length of the assessment period (days).}
 }
 \value{
-Numeric scalar. Energy requirements in megajoules.
+Numeric scalar. Energy required to provide all draught power (traction/work) by cohort (MJ/cohort/assessment period).
+
+Non-zero values are expected only for fiber-producing species (CTL, BFL CML) and assumed cohorts ("MA").'
 }
 \description{
-Estimates energy expenditure on animal work for the assessment duration, adjusting camelid values when required.
+Calculates the net energy demand (MJ) associated with animal work over the
+assessment period for animals involved in draught power generation.
+}
+\details{
+This function provides the work-related energy term used in a biophysical
+allocation framework to apportion emissions between milk and other co-products
+in multifunctional livestock production systems.
+
+The approach implements the IDF (2022) standard, adapted from Thoma and Nemecek (2020), and is consistent with
+FAO LEAP livestock LCA guidelines (FAO, 2016a, 2016b, 2016c) and with ISO 14044:2006 (Section 4.3.4.2, Step 2).
+
+In accordance with ISO 14044:2006 (Section 4.3.4.2, Step 2), known processing or
+biophysical relationships may be used to assign shared inputs and outputs of a
+single production unit to individual products or sub-units. In livestock systems,
+this includes apportioning shared feed and energy use according to physiological
+energy requirements (e.g., net energy for lactation, growth..etc.). If the
+resulting process remains multifunctional, these energy terms may subsequently
+be used to derive allocation factors among co-products.
+
+Total work-related energy is computed for species (\code{CTL}, \code{BFL}, \code{CML})
+and cohorts (\code{MA}) assumed to be potentially involved in draught power generation, and
+is calculated as follows:
+
+\itemize{
+\item \code{energy_allocation_work = work_energy_requirement * assessment_duration}
+}
+
+where \code{work_energy_requirement} represents the daily energy requirement for
+animal work (MJ/head/day) and is obtained from
+\code{\link[gleam]{calc_net_energy_work}}.
+}
+\references{
+ISO. 2006. Environmental management — Life cycle assessment — Requirements and
+guidelines (ISO 14044:2006). International Organization for Standardization, Geneva.
+
+IDF. 2022. The IDF Global Carbon Footprint Standard for the Dairy Sector.
+Bulletin of the IDF No. 520/2022. International Dairy Federation, Brussels.
+
+Thoma, G., and T. Nemecek. 2020. Allocation between milk and meat in dairy LCA:
+Critical discussion of the IDF’s standard methodology. Proceedings of the
+12th International Conference on Life Cycle Assessment of Food (LCAFood 2020),
+pp. 83–89, 13–16 October, Berlin, Germany.
+
+FAO. 2016a. Environmental performance of large ruminant supply chains:
+Guidelines for assessment. Livestock Environmental Assessment and Performance
+(LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016b. Greenhouse gas emissions and fossil energy use from small ruminant
+supply chains: Guidelines for assessment. Livestock Environmental Assessment
+and Performance (LEAP) Partnership. FAO, Rome, Italy.
+
+FAO. 2016c. Greenhouse gas emissions and fossil energy use from poultry supply
+chains: Guidelines for assessment. Livestock Environmental Assessment and
+Performance (LEAP) Partnership. FAO, Rome, Italy.
 }

--- a/man/calc_net_energy_lactation.Rd
+++ b/man/calc_net_energy_lactation.Rd
@@ -17,9 +17,7 @@ calc_net_energy_lactation(
   ckg,
   wkg,
   lact,
-  parturition_rate,
-  lambing_interval,
-  weaning_age
+  parturition_rate
 )
 }
 \arguments{
@@ -66,11 +64,7 @@ This value can be calculated as the total number of offspring born divided by th
 
 \item{lact}{Numeric. Duration of the lactation period, defined as the number of days during which the animal is lactating (days).}
 
-\item{parturition_rate}{Numeric. Numeric. Average annual number of parturitions per female animal (fraction). At herd level, calculated as offspring delivered divided by the number of adult females.}
-
-\item{lambing_interval}{Numeric. Average time interval between two successive births (days)}
-
-\item{weaning_age}{Numeric. Average age of the juvenile animals at weaning (days)}
+\item{parturition_rate}{Numeric. Average annual number of parturitions per female animal (#). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
 }
 \value{
 Numeric. Energy required for lactation. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
@@ -88,29 +82,31 @@ IPCC Tier 2 guidelines, lactation energy is calculated as a function of the
 \strong{quantity of milk produced} and a \strong{species-specific energy cost per unit
 of milk}.
 
-\itemize{\strong{For CTL, BFL, CML, SHP and GTS}:
+\strong{For CTL, BFL, CML, SHP and GTS}:
+
 Total milk production includes:
 \itemize{
 \item milk extracted for human consumption (\code{milk_yield})
-\item milk consumed directly by offspring (\code{milk_from_offspring})
-when milk yield is not directly observed (e.g., suckling systems).
+\item milk consumed directly by offspring (\code{milk_for_offspring})
 }
 
 Lactation energy requirements are applied \strong{only to adult females} and are
-scaled by the proportion of animals that are lactating within the cohort
-(\code{milking_fraction}).
+scaled by the proportion of milked (\code{milking_fraction}) or lactating
+(\code{parturition_rate}) animals within the cohort.
 
 In general form, lactation energy is computed as:
 
 \deqn{
 energy\_lactation =
-(milk\_yield + milk\_from\_offspring)
+(milk\_yield \times milking\_fraction + milk\_for\_offspring)
 \times energy\_milk
-\times milking\_fraction
+
 }
 
-where \code{energy_milk} is a species-specific coefficient representing the
-net energy cost of producing one kilogram of milk (MJ kg\eqn{^{-1}}).
+where:
+
+\code{energy_milk} is a species-specific coefficient representing the
+net energy cost of producing one kilogram of milk (MJ kg\eqn{^{-1}})
 
 Species-specific values of \code{energy_milk} are:
 \itemize{
@@ -121,32 +117,23 @@ Species-specific values of \code{energy_milk} are:
 \item \code{GTS}: 3.0 (AFRC, 1998).
 }
 
-When milk yield is not directly observed the amount of milk required to rear offspring
-is aproximated at \strong{5 kilograms of milk per
-kilogram of live-weight gain to weaning}:
+\code{milk_for_offspring} is the daily amount of milk required to rear offspring across the year (kg day\eqn{^{-1}}).
+It is calculated assuming that \strong{5 kg of milk are required for each kilogram of live-weight gain up to weaning}, using the equation below.
 
 \deqn{
-milk\_from\_offspring =
+milk\_for\_offspring =
 \frac{parturition\_rate \times 5 \times (wkg - ckg)}
-{assessment\_duration} \code(AFRC, 1990)
-}
-}
-
-\itemize{\strong{For PGS} — NRC (1998).
-
-For pigs, lactation energy is implemented as a \strong{per-litter energy requirement}
-adjusted to the fraction of the reproductive cycle spent in lactation.
-
-The adjustment factor is defined as:
-
-\deqn{
-cadj = \frac{lact}{idle + gest + lact}
+{365} \code(AFRC, 1990)
 }
 
-where \eqn{lact}, \eqn{idle}, and \eqn{gest} represent the durations (days)
-of lactation, non-productive (idle), and gestation phases, respectively.
+For \code{SHP} and \code{GTS}, \code{milk_for_offspring} also accounts for
+the average number of offspring per birth by multiplying by \code{litsize}.
 
-Lactation energy per sow per day is calculated as:
+\strong{For PGS} — NRC (1998):
+
+For pigs, lactation energy accounts only for the milk consumed directly by offspring (\code{milk_for_offspring})
+adjusted by the fraction of the reproductive cycle spent in lactation (\code{cadj}),
+and is calculated as follows:
 
 \deqn{
 energy\_lactation =
@@ -169,8 +156,12 @@ energy (\eqn{C_{conv}}, fraction),
 \item \code{litsize} is litter size,
 \item \code{dr1} is the proportion of stillborn piglets,
 \item \eqn{wkg} and \eqn{ckg} are live weights at weaning and at birth,
-respectively (kg).
-}
+respectively (kg),
+\item \eqn{cadj} is the fraction of the reproductive cycle spent in lactation calculated as
+
+\deqn{
+   cadj = \frac{lact}{idle + gest + lact}
+   }
 }
 }
 \references{

--- a/man/calc_net_energy_lactation.Rd
+++ b/man/calc_net_energy_lactation.Rd
@@ -19,7 +19,7 @@ calc_net_energy_lactation(
   lact,
   parturition_rate,
   lambing_interval,
-  assessment_duration
+  weaning_age
 )
 }
 \arguments{
@@ -70,7 +70,7 @@ This value can be calculated as the total number of offspring born divided by th
 
 \item{lambing_interval}{Numeric. Average time interval between two successive births (days)}
 
-\item{assessment_duration}{Numeric. Length of the assessment period (days)}
+\item{weaning_age}{Numeric. Average age of the juvenile animals at weaning (days)}
 }
 \value{
 Numeric. Energy required for lactation. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).

--- a/man/calc_net_energy_pregnancy.Rd
+++ b/man/calc_net_energy_pregnancy.Rd
@@ -11,6 +11,8 @@ calc_net_energy_pregnancy(
   parturition_rate,
   litsize,
   gest,
+  idle,
+  lact,
   duration,
   offtake_rate
 )
@@ -40,12 +42,15 @@ production stage of the animals. Supported values include:
 
 \item{nemain}{Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal in equilibrium such that body energy is neither gained nor lost. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).}
 
-\item{parturition_rate}{Numeric. Numeric. Average annual number of parturitions per female animal (fraction).
-At herd level, calculated as offspring delivered divided by the number of adult females.}
+\item{parturition_rate}{Numeric. Average annual number of parturitions per female animal (#). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
 
 \item{litsize}{Numeric. Average number of offspring born per parturition (#). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.}
 
 \item{gest}{Numeric. Duration of pregnancy period (days).}
+
+\item{idle}{Numeric. Period during which the animal is not performing any productive physiological function such as pregnancy or lactation (days).}
+
+\item{lact}{Numeric. Duration of the lactation period, defined as the number of days during which the animal is lactating (days).}
 
 \item{duration}{Numeric. Amount of time that each animal spends in a specific cohort (days).}
 
@@ -56,66 +61,100 @@ Numeric. Energy required for pregnancy for pregnant adult females (MJ/head/day).
 }
 \description{
 Computes the \strong{energy requirement for pregnancy} (MJ/head/day) for pregnant
-females. This approach follows the IPCC Tier 2 partitioning framework, where
-pregnancy energy is expressed as a fraction of the energy required for
-maintenance and is applied only to \strong{female cohorts}.
+females. This approach follows the IPCC Tier 2 partitioning framework and is applied
+only to \strong{female cohorts}.
 }
 \details{
-Pregnancy energy is applied only to female cohorts and is scaled according to
-reproductive exposure during the cohort stage:
-\itemize{
-\item For adult females (\code{FA}), pregnancy energy is proportional to
-\code{parturition_rate}.
-\item For replacement females (\code{FS}), pregnancy energy is applied only
-to the fraction of animals that remain in the cohort, using
-\code{(1 - offtake_rate)}, and is scaled to the time pregnant within the
-cohort using \code{gest / duration}.
-}
+Pregnancy energy is calculated \strong{only for female cohorts}
+(i.e., \code{FA} and \code{FS}) and represents the additional
+energy required to support gestation.
 
-Specifics by species:
+For \code{FA}, pregnancy energy requirements are adjusted to account
+for the proportion of time animals spend in gestation.
+
+For \code{FS}, only a fraction of animals is assumed to be of reproductive age;
+pregnancy energy requirements are therefore scaled accordingly.
 
 \itemize{
-\item
-\strong{CTL and BFL} — IPCC (2006, 2019).
-Pregnancy is approximated as 10\\% of maintenance energy averaged over the year:
+\item For \strong{CTL and BFL} — IPCC (2006, 2019):
+
+Pregnancy energy is approximated as 10\% of maintenance energy.
 \itemize{
 \item \code{FA}:
-\deqn{energy\_pregnancy = 0.10 \times nemain \times parturition\_rate}
+\deqn{
+      energy\_pregnancy =
+      0.10 \times nemain \times parturition\_rate \times \frac{gest}{365}
+      }
 \item \code{FS}:
-\deqn{energy\_pregnancy = 0.10 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
+\deqn{
+      energy\_pregnancy =
+      0.10 \times nemain \times \frac{gest}{duration}
+      \times (1 - offtake\_rate)
+      }
 }
 
-\strong{CML} — (Wardeh, 2004)
+\item For \strong{CML} — Wardeh (2004):
+
+Pregnancy energy is estimated as 12\% of maintenance energy.
 \itemize{
 \item \code{FA}:
-\deqn{energy\_pregnancy = 0.12 \times nemain \times parturition\_rate}
+\deqn{
+      energy\_pregnancy =
+      0.12 \times nemain \times parturition\_rate
+      }
 \item \code{FS}:
-\deqn{energy\_pregnancy = 0.12 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
+\deqn{
+      energy\_pregnancy =
+      0.12 \times nemain \times \frac{gest}{duration}
+      \times (1 - offtake\_rate)
+      }
 }
 
-\strong{SHP and GTS} — IPCC (2006, 2019).
-Pregnancy is calculated as a litter-size dependent fraction of maintenance:
-\deqn{energy\_pregnancy = cpreg(litsize) \times nemain \times parturition\_rate}
+\item For \strong{SHP and GTS} — IPCC (2006, 2019):
+
+Pregnancy energy is calculated as a litter-size–dependent fraction
+of maintenance energy.
+\itemize{
+\item \code{FA}:
+\deqn{
+      energy\_pregnancy =
+      nemain \times cpreg \times parturition\_rate \times \frac{gest}{365}
+      }
 where \eqn{cpreg} is defined as:
 \itemize{
 \item If \eqn{1 \le litsize \le 2}:
-\deqn{cpreg = 0.077 \times (2 - litsize) + 0.126 \times (litsize - 1)}
-\item If \eqn{litsize > 2}: \deqn{cpreg = 0.150}
+\deqn{
+          cpreg = 0.077 \times (2 - litsize) + 0.126 \times (litsize - 1)
+          }
+\item If \eqn{litsize > 2}:
+\deqn{cpreg = 0.150}
 }
-For replacement females (\code{FS}), the implementation applies the single-birth
-coefficient scaled by pregnancy exposure:
-\deqn{energy\_pregnancy = 0.077 \times nemain \times (gest/duration) \times (1-offtake\_rate)}
+\item \code{FS} -
+Pregnancy energy is calculated using the single-birth coefficient
+and scaled to the proportion of reproductive individuals in the cohort.
+\deqn{
+      energy\_pregnancy =
+      0.077 \times nemain \times \frac{gest}{duration}
+      \times (1 - offtake\_rate)
+      }
+}
 
-\strong{PGS} — (NRC, 1998):
-Pregnancy energy is implemented as a litter-based daily requirement using a
-gestation coefficient (\eqn{cgest}, MJ piglet\eqn{^{-1}}):
+\item For \strong{PGS} — NRC (1998):
+
 \itemize{
 \item \code{FA}:
-\deqn{energy\_pregnancy = cgest \times litsize \times parturition\_rate}
+\deqn{
+      energy\_pregnancy = cgest \times litsize \times \frac{gest}{lact + gest + idle}
+      }
 \item \code{FS}:
-\deqn{energy\_pregnancy = cgest \times litsize \times parturition\_rate \times (gest/duration) \times (1-offtake\_rate)}
+\deqn{
+      energy\_pregnancy =
+      cgest \times litsize \times \frac{gest}{duration}
+      \times (1 - offtake\_rate)
+      }
+The default value for the gestation coefficient is
+\eqn{cgest = 0.14985} MJ piglet\eqn{^{-1}}.
 }
-with default \eqn{cgest = 0.14985} MJ piglet\eqn{^{-1}}.
 }
 }
 \references{

--- a/man/calc_totals_by_cohort.Rd
+++ b/man/calc_totals_by_cohort.Rd
@@ -15,7 +15,7 @@ calc_totals_by_cohort(value, size, assessment_duration, variable_type)
 
 \item{size}{Numeric vector. Number of heads in the specific cohort.}
 
-\item{assessment_duration}{Numeric vector. Duration of the assessment (days).}
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 
 \item{variable_type}{Character vector. Variable group classification:
 \itemize{

--- a/man/compute_fibre_output.Rd
+++ b/man/compute_fibre_output.Rd
@@ -9,12 +9,12 @@ compute_fibre_output(fibre_prod, assessment_duration, size)
 \arguments{
 \item{fibre_prod}{Numeric. Fibre yield per head per year (kg/head/year).}
 
-\item{assessment_duration}{Numeric. Number of assessment days used to annualise fibre output.}
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 
 \item{size}{Numeric. Herd size (heads) for the cohort.}
 }
 \value{
-Numeric. Fibre production per cohort (kg/year).
+Numeric. Total fibre produced over the assessment period  by cohort (kg /cohort/assessment period).
 }
 \description{
 Compute Fibre Production

--- a/man/compute_meat_outputs.Rd
+++ b/man/compute_meat_outputs.Rd
@@ -9,7 +9,8 @@ compute_meat_outputs(
   slaughter_weight,
   carcass_dressing_percentage,
   bone_free_meat_fraction,
-  meat_protein
+  meat_protein,
+  assessment_duration
 )
 }
 \arguments{
@@ -22,13 +23,15 @@ compute_meat_outputs(
 \item{bone_free_meat_fraction}{Numeric. Share of carcass that becomes boneless meat (fraction).}
 
 \item{meat_protein}{Numeric. Protein fraction of boneless meat (kg protein per kg meat).}
+
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 }
 \value{
 Named list containing:
-\item{output_meat_production_liveweight}{Numeric. Meat production as live weight (kg/year).}
-\item{output_meat_production_carcassweight}{Numeric. Meat production as carcass weight (kg/year).}
-\item{output_meat_production_meat}{Numeric. Boneless meat production (kg/year).}
-\item{output_meat_production_protein}{Numeric. Meat protein production (kg protein/year).}
+\item{output_meat_production_liveweight}{Numeric. Total meat produced as live weight over the assessment period by cohort (kg/cohort/year).}
+\item{output_meat_production_carcassweight}{Numeric. Total meat as carcass weight (excluding organs, and other by-products after dressing) produced over the assessment period by cohort, (kg/cohort/year).}
+\item{output_meat_production_meat}{Numeric. Total bone-free-meat (excluding bones, organs, and other by-products after dressing and bone removal) produced over the assessment period by cohort, (kg/cohort/year)}
+\item{output_meat_production_protein}{Numeric. Total meat protein (excluding bones, organs, and other by-products after dressing and bone removal) produced over the assessment period by cohort (kg protein/cohort/year).}
 }
 \description{
 Produces liveweight, carcass weight, boneless meat, and meat protein using the

--- a/man/compute_meat_outputs.Rd
+++ b/man/compute_meat_outputs.Rd
@@ -5,7 +5,7 @@
 \title{Compute Meat Production Outputs}
 \usage{
 compute_meat_outputs(
-  offtake_number,
+  offtake_number_assessment,
   slaughter_weight,
   carcass_dressing_percentage,
   bone_free_meat_fraction,
@@ -14,7 +14,7 @@ compute_meat_outputs(
 )
 }
 \arguments{
-\item{offtake_number}{Numeric. Number of animals removed via offtake (head/year).}
+\item{offtake_number_assessment}{Numeric. Number of animals removed via offtake (head/year).}
 
 \item{slaughter_weight}{Numeric. Live weight at slaughter (kg).}
 
@@ -23,8 +23,6 @@ compute_meat_outputs(
 \item{bone_free_meat_fraction}{Numeric. Share of carcass that becomes boneless meat (fraction).}
 
 \item{meat_protein}{Numeric. Protein fraction of boneless meat (kg protein per kg meat).}
-
-\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 }
 \value{
 Named list containing:

--- a/man/compute_milk_outputs.Rd
+++ b/man/compute_milk_outputs.Rd
@@ -20,7 +20,7 @@ compute_milk_outputs(
 \arguments{
 \item{milk_yield}{Numeric. Milk yield per head per day (kg/day).}
 
-\item{assessment_duration}{Numeric. Number of assessment days in the year used to annualise outputs.}
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 
 \item{size}{Numeric. Herd cohort size (heads).}
 
@@ -41,9 +41,9 @@ computed animal-specific lactose but used standard_lactose in the energy calcula
 }
 \value{
 Named list containing:
-\item{output_milk_mass_production}{Numeric. Milk production (kg/year).}
-\item{output_milk_protein_production}{Numeric. Milk protein production (kg protein/year).}
-\item{output_milk_fpcm_production}{Numeric. Fat-protein-corrected milk production (kg FPCM/year).}
+\item{output_milk_mass_production}{Numeric. Total milk production produced over the assessment period (kg/herd/assessment period).}
+\item{output_milk_protein_production}{Numeric. Total milk protein production produced over the assessment period (kg protein/herd/assessment period).}
+\item{output_milk_fpcm_production}{Numeric. Total Fat-protein-corrected milk (FPCM) produced over the assessment period  (kg/herd/assessment period). Default fat and protein content=0.04 and 0.033.}
 }
 \description{
 Returns milk mass, protein, and FPCM using the IDF energy formulation while preserving

--- a/man/run_allocation.Rd
+++ b/man/run_allocation.Rd
@@ -12,7 +12,7 @@ run_allocation(
   standard_fat = 0.04,
   standard_lactose = 0.048,
   ratio_ne_me_camelids = 0.43,
-  assessment_duration_days = 365
+  assessment_duration = assessment_duration
 )
 }
 \arguments{
@@ -30,7 +30,7 @@ run_allocation(
 
 \item{ratio_ne_me_camelids}{Numeric scalar for the net-to-metabolizable energy conversion for camelids.}
 
-\item{assessment_duration_days}{Numeric scalar giving the assessment period in days.}
+\item{assessment_duration}{Numeric scalar. Length of the assessment period (days).}
 }
 \value{
 A named list of three \code{data.table} objects:

--- a/man/run_production_cohort.Rd
+++ b/man/run_production_cohort.Rd
@@ -7,7 +7,7 @@
 run_production_cohort(
   data,
   lactose_lookup,
-  assessment_duration = 365,
+  assessment_duration = assessment_duration,
   standard_lactose = 0.048
 )
 }
@@ -19,8 +19,7 @@ yields, fibre production, slaughter characteristics, and classifier columns such
 \item{lactose_lookup}{data.table. Lookup table mapping \code{Animal_short} to lactose percentage values
 in column \code{Value}.}
 
-\item{assessment_duration}{Numeric. Number of assessment days used to annualise production outputs.
-Defaults to \code{365}.}
+\item{assessment_duration}{Numeric. Length of the assessment period (days)}
 
 \item{standard_lactose}{Numeric. Reference lactose fraction used for FPCM energy calculations.
 Defaults to \code{0.048} (reflecting IDF 2022 guidance).}

--- a/man/run_production_cohort.Rd
+++ b/man/run_production_cohort.Rd
@@ -7,7 +7,7 @@
 run_production_cohort(
   data,
   lactose_lookup,
-  assessment_duration = assessment_duration,
+  assessment_duration = 365,
   standard_lactose = 0.048
 )
 }

--- a/tests/testthat/test-allocation_core.R
+++ b/tests/testthat/test-allocation_core.R
@@ -56,7 +56,8 @@ test_that("calc_energy_allocation_meat returns correct value for cattle female",
     cohort_code = "FA",
     slaughter_liveweight = 500,
     birth_liveweight = 40,
-    output_meat_production_liveweight = 100
+    output_meat_production_liveweight = 100,
+    ratio_ne_to_me = 0.43
   )
 
   expect_type(result, "double")
@@ -74,7 +75,8 @@ test_that("calc_energy_allocation_meat returns correct value for cattle male", {
     cohort_code = "MA",
     slaughter_liveweight = 600,
     birth_liveweight = 45,
-    output_meat_production_liveweight = 150
+    output_meat_production_liveweight = 150,
+    ratio_ne_to_me = 0.43
   )
 
   expect_type(result, "double")
@@ -89,13 +91,14 @@ test_that("calc_energy_allocation_meat returns correct value for camelids", {
     cohort_code = "FA",
     slaughter_liveweight = 450,
     birth_liveweight = 35,
-    output_meat_production_liveweight = 80
+    output_meat_production_liveweight = 80,
+    ratio_ne_to_me = 0.43
   )
 
   expect_type(result, "double")
   expect_true(!is.na(result))
   # For CML: specific_energy = (41.8 * (slaughter - birth)) / slaughter
-  expected_specific <- (41.8 * (450 - 35)) / 450
+  expected_specific <- (41.8 * 0.43 * (450 - 35)) / 450
   expect_equal(result, expected_specific * 80)
 })
 
@@ -105,7 +108,8 @@ test_that("calc_energy_allocation_meat returns correct value for sheep female", 
     cohort_code = "FA",
     slaughter_liveweight = 60,
     birth_liveweight = 4,
-    output_meat_production_liveweight = 20
+    output_meat_production_liveweight = 20,
+    ratio_ne_to_me = 0.43
   )
 
   expect_type(result, "double")
@@ -122,7 +126,8 @@ test_that("calc_energy_allocation_meat returns correct value for sheep male", {
     cohort_code = "MA",
     slaughter_liveweight = 70,
     birth_liveweight = 4.5,
-    output_meat_production_liveweight = 25
+    output_meat_production_liveweight = 25,
+    ratio_ne_to_me = 0.43
   )
 
   expect_type(result, "double")
@@ -136,7 +141,8 @@ test_that("calc_energy_allocation_meat returns correct value for goats", {
     cohort_code = "FA",
     slaughter_liveweight = 50,
     birth_liveweight = 3.5,
-    output_meat_production_liveweight = 15
+    output_meat_production_liveweight = 15,
+    ratio_ne_to_me = 0.43
   )
 
   expect_type(result, "double")
@@ -152,7 +158,8 @@ test_that("calc_energy_allocation_meat returns NA for pigs", {
     cohort_code = "FA",
     slaughter_liveweight = 150,
     birth_liveweight = 1.5,
-    output_meat_production_liveweight = 100
+    output_meat_production_liveweight = 100,
+    ratio_ne_to_me = 0.43
   )
 
   expect_true(is.na(result))
@@ -165,7 +172,8 @@ test_that("calc_energy_allocation_meat validates animal species", {
       cohort_code = "FA",
       slaughter_liveweight = 500,
       birth_liveweight = 40,
-      output_meat_production_liveweight = 100
+      output_meat_production_liveweight = 100,
+      ratio_ne_to_me = 0.43
     ),
     "must be one of"
   )
@@ -178,7 +186,8 @@ test_that("calc_energy_allocation_meat validates cohort codes", {
       cohort_code = "INVALID",
       slaughter_liveweight = 500,
       birth_liveweight = 40,
-      output_meat_production_liveweight = 100
+      output_meat_production_liveweight = 100,
+      ratio_ne_to_me = 0.43
     ),
     "must be one of"
   )
@@ -191,7 +200,8 @@ test_that("calc_energy_allocation_meat validates weight bounds", {
       cohort_code = "FA",
       slaughter_liveweight = -10,
       birth_liveweight = 40,
-      output_meat_production_liveweight = 100
+      output_meat_production_liveweight = 100,
+      ratio_ne_to_me = 0.43
     ),
     "must be between 0 and 2000"
   )
@@ -201,7 +211,8 @@ test_that("calc_energy_allocation_meat validates weight bounds", {
       cohort_code = "FA",
       slaughter_liveweight = 500,
       birth_liveweight = 300,
-      output_meat_production_liveweight = 100
+      output_meat_production_liveweight = 100,
+      ratio_ne_to_me = 0.43
     ),
     "must be between 0 and 200"
   )

--- a/tests/testthat/test-allocation_core.R
+++ b/tests/testthat/test-allocation_core.R
@@ -56,7 +56,7 @@ test_that("calc_energy_allocation_meat returns correct value for cattle female",
     cohort_code = "FA",
     slaughter_liveweight = 500,
     birth_liveweight = 40,
-    meat_output_liveweight = 100
+    output_meat_production_liveweight = 100
   )
 
   expect_type(result, "double")
@@ -74,7 +74,7 @@ test_that("calc_energy_allocation_meat returns correct value for cattle male", {
     cohort_code = "MA",
     slaughter_liveweight = 600,
     birth_liveweight = 45,
-    meat_output_liveweight = 150
+    output_meat_production_liveweight = 150
   )
 
   expect_type(result, "double")
@@ -89,7 +89,7 @@ test_that("calc_energy_allocation_meat returns correct value for camelids", {
     cohort_code = "FA",
     slaughter_liveweight = 450,
     birth_liveweight = 35,
-    meat_output_liveweight = 80
+    output_meat_production_liveweight = 80
   )
 
   expect_type(result, "double")
@@ -105,7 +105,7 @@ test_that("calc_energy_allocation_meat returns correct value for sheep female", 
     cohort_code = "FA",
     slaughter_liveweight = 60,
     birth_liveweight = 4,
-    meat_output_liveweight = 20
+    output_meat_production_liveweight = 20
   )
 
   expect_type(result, "double")
@@ -122,7 +122,7 @@ test_that("calc_energy_allocation_meat returns correct value for sheep male", {
     cohort_code = "MA",
     slaughter_liveweight = 70,
     birth_liveweight = 4.5,
-    meat_output_liveweight = 25
+    output_meat_production_liveweight = 25
   )
 
   expect_type(result, "double")
@@ -136,7 +136,7 @@ test_that("calc_energy_allocation_meat returns correct value for goats", {
     cohort_code = "FA",
     slaughter_liveweight = 50,
     birth_liveweight = 3.5,
-    meat_output_liveweight = 15
+    output_meat_production_liveweight = 15
   )
 
   expect_type(result, "double")
@@ -152,7 +152,7 @@ test_that("calc_energy_allocation_meat returns NA for pigs", {
     cohort_code = "FA",
     slaughter_liveweight = 150,
     birth_liveweight = 1.5,
-    meat_output_liveweight = 100
+    output_meat_production_liveweight = 100
   )
 
   expect_true(is.na(result))
@@ -165,7 +165,7 @@ test_that("calc_energy_allocation_meat validates animal species", {
       cohort_code = "FA",
       slaughter_liveweight = 500,
       birth_liveweight = 40,
-      meat_output_liveweight = 100
+      output_meat_production_liveweight = 100
     ),
     "must be one of"
   )
@@ -178,7 +178,7 @@ test_that("calc_energy_allocation_meat validates cohort codes", {
       cohort_code = "INVALID",
       slaughter_liveweight = 500,
       birth_liveweight = 40,
-      meat_output_liveweight = 100
+      output_meat_production_liveweight = 100
     ),
     "must be one of"
   )
@@ -191,7 +191,7 @@ test_that("calc_energy_allocation_meat validates weight bounds", {
       cohort_code = "FA",
       slaughter_liveweight = -10,
       birth_liveweight = 40,
-      meat_output_liveweight = 100
+      output_meat_production_liveweight = 100
     ),
     "must be between 0 and 2000"
   )
@@ -201,7 +201,7 @@ test_that("calc_energy_allocation_meat validates weight bounds", {
       cohort_code = "FA",
       slaughter_liveweight = 500,
       birth_liveweight = 300,
-      meat_output_liveweight = 100
+      output_meat_production_liveweight = 100
     ),
     "must be between 0 and 200"
   )

--- a/tests/testthat/test-allocation_core.R
+++ b/tests/testthat/test-allocation_core.R
@@ -268,7 +268,8 @@ test_that("calc_energy_allocation_fibre uses default assessment_duration", {
   result <- calc_energy_allocation_fibre(
     animal = "SHP",
     fibre_energy_requirement = 5,
-    ratio_ne_to_me = 0.43
+    ratio_ne_to_me = 0.43,
+    assessment_duration = 365
   )
 
   expect_equal(result, 5 * 365)  # Default is 365 days
@@ -322,7 +323,8 @@ test_that("calc_energy_allocation_work uses default assessment_duration", {
   result <- calc_energy_allocation_work(
     animal = "CTL",
     work_energy_requirement = 8,
-    ratio_ne_to_me = 0.43
+    ratio_ne_to_me = 0.43,
+    assessment_duration = 365
   )
 
   expect_equal(result, 8 * 365)  # Default is 365 days

--- a/tests/testthat/test-energy_requirements_core.R
+++ b/tests/testthat/test-energy_requirements_core.R
@@ -225,7 +225,7 @@ test_that("calc_net_energy_lactation returns correct values for cattle", {
     animal = "CTL", cohort = "FA",
     milking_fraction = 0.8, milk_yield = 20, milk_fat = 0.04,
     idle = 0, gest = 0, litsize = 1, dr1 = 0, ckg = 35, wkg = 90,
-    lact = 0, parturition_rate = 0.8, lambing_interval = 400, weaning_age = 365
+    lact = 0, parturition_rate = 0.8
   )
   
   expected <- ((20 * 0.8) + (0.8 * 5 * (90 - 35) / 365)) * (0.04 * 100 * 0.40 + 1.47)
@@ -237,9 +237,9 @@ test_that("calc_net_energy_lactation handles sheep with litter size", {
     animal = "SHP", cohort = "FA",
     milking_fraction = 0.9, milk_yield = 1.5, milk_fat = 0.06,
     idle = 0, gest = 0, litsize = 1.5, dr1 = 0, ckg = 4, wkg = 18,
-    lact = 0, parturition_rate = 1.2, lambing_interval = 400, weaning_age = 365
+    lact = 0, parturition_rate = 1.2
   )
-  expected <- ((1.5 * 0.9) + (1.5 * (1.2 / 400) * 5 * (18 - 4) / 365)) * 4.6
+  expected <- ((1.5 * 0.9) + (1.5 * 1.2 * 5 * (18 - 4) / 365)) * 4.6
   expect_equal(result, expected)
 })
 
@@ -248,7 +248,7 @@ test_that("calc_net_energy_lactation handles pigs", {
     animal = "PGS", cohort = "FA",
     milking_fraction = 0, milk_yield = 0, milk_fat = 0,
     idle = 0.2, gest = 0.3, litsize = 10, dr1 = 0.1, ckg = 1.5, wkg = 8,
-    lact = 0.5, parturition_rate = 2.2, lambing_interval = 400, weaning_age = 365
+    lact = 0.5, parturition_rate = 2.2
   )
   cadj <- 0.5 / (0.2 + 0.3 + 0.5)
   expected <- 10 * (1 - 0.5 * 0.1) * ((0.02059 * (8 - 1.5) * 1000 / 0.5) - (0.3766 / 0.67)) * cadj

--- a/tests/testthat/test-energy_requirements_core.R
+++ b/tests/testthat/test-energy_requirements_core.R
@@ -326,16 +326,20 @@ test_that("calc_net_energy_pregnancy returns correct values for cattle", {
   result <- calc_net_energy_pregnancy(
     animal = "CTL", cohort = "FA",
     nemain = 15.0, parturition_rate = 0.8,
-   litsize = 1, gest = 283,  duration = 365, offtake_rate = 0.2
+   litsize = 1, gest = 283,  
+   idle = 10, lact = 30,
+   duration = 730, offtake_rate = 0.2
   )
-  expected <- 15.0 * 0.1 * 0.8
+  expected <- 15.0 * 0.1 * 0.8 * 283 / 365
   expect_equal(result, expected)
 
   # Test subadult female
   result <- calc_net_energy_pregnancy(
     animal = "CTL", cohort = "FS",
     nemain = 12.0, parturition_rate = 0.8,
-    litsize = 1, gest = 283, duration = 730, offtake_rate = 0.2
+    litsize = 1, gest = 283, 
+    idle = 10, lact = 30,
+    duration = 730, offtake_rate = 0.2
   )
   expected <- (12.0 * 0.1) * (283 / 730) * (1 - 0.2)
   expect_equal(result, expected)
@@ -345,20 +349,24 @@ test_that("calc_net_energy_pregnancy handles sheep with litter size effects", {
   # Test with litter size 1.5
   result <- calc_net_energy_pregnancy(
     animal = "SHP", cohort = "FA",
-    nemain = 8.0, parturition_rate = 1.2, litsize = 1.5,
-    gest = 152, duration = 365, offtake_rate = 0.1
+    nemain = 8.0, parturition_rate = 1.2, 
+    litsize = 1.5, gest = 152, 
+    idle = 10, lact = 30,
+    duration = 700, offtake_rate = 0.1
   )
   cpreg <- (0.077 * 0.5 + 0.126 * 0.5)
-  expected <- 8.0 * cpreg * 1.2
+  expected <- 8.0 * cpreg * 1.2 * 152 / 365
   expect_equal(result, expected)
 
   # Test with litter size > 2
   result <- calc_net_energy_pregnancy(
     animal = "SHP", cohort = "FA",
     nemain = 8.0, parturition_rate = 1.2,
-    litsize = 2.5, gest = 152, duration = 365, offtake_rate = 0.1
+    litsize = 2.5, gest = 152, 
+    idle = 10, lact = 30,
+    duration = 365, offtake_rate = 0.1
   )
-  expected <- 8.0 * 0.150 * 1.2
+  expected <- 8.0 * 0.150 * 1.2 * 152 / 365
   expect_equal(result, expected)
 })
 
@@ -366,9 +374,11 @@ test_that("calc_net_energy_pregnancy handles pigs", {
   result <- calc_net_energy_pregnancy(
     animal = "PGS", cohort = "FA",
     nemain = 12.0, parturition_rate = 2.2,
-    litsize = 10, gest = 115, duration = 365, offtake_rate = 0.1
+    litsize = 10, gest = 115, 
+    idle = 10, lact = 30,
+    duration = 365, offtake_rate = 0.1
   )
-  expected <- 0.14985 * 10 * 2.2
+  expected <- 0.14985 * 10 * 115 / (10 + 115 + 30)
   expect_equal(result, expected)
 })
 

--- a/tests/testthat/test-energy_requirements_core.R
+++ b/tests/testthat/test-energy_requirements_core.R
@@ -225,9 +225,10 @@ test_that("calc_net_energy_lactation returns correct values for cattle", {
     animal = "CTL", cohort = "FA",
     milking_fraction = 0.8, milk_yield = 20, milk_fat = 0.04,
     idle = 0, gest = 0, litsize = 1, dr1 = 0, ckg = 35, wkg = 90,
-    lact = 0, parturition_rate = 0.8, lambing_interval = 365, assessment_duration = 365
+    lact = 0, parturition_rate = 0.8, lambing_interval = 400, weaning_age = 365
   )
-  expected <- ((20 * 0.8) + (0.8 * 5 * (90 - 35)) / 365) * (0.04 * 100 * 0.40 + 1.47)
+  
+  expected <- ((20 * 0.8) + (0.8 * 5 * (90 - 35) / 365)) * (0.04 * 100 * 0.40 + 1.47)
   expect_equal(result, expected)
 })
 
@@ -236,9 +237,9 @@ test_that("calc_net_energy_lactation handles sheep with litter size", {
     animal = "SHP", cohort = "FA",
     milking_fraction = 0.9, milk_yield = 1.5, milk_fat = 0.06,
     idle = 0, gest = 0, litsize = 1.5, dr1 = 0, ckg = 4, wkg = 18,
-    lact = 0, parturition_rate = 1.2, lambing_interval = 365, assessment_duration = 365
+    lact = 0, parturition_rate = 1.2, lambing_interval = 400, weaning_age = 365
   )
-  expected <- ((1.5 * 0.9) + (1.5 * (365 * 1.2 / 365) * 5 * (18 - 4)) / 365) * 4.6
+  expected <- ((1.5 * 0.9) + (1.5 * (1.2 / 400) * 5 * (18 - 4) / 365)) * 4.6
   expect_equal(result, expected)
 })
 
@@ -247,7 +248,7 @@ test_that("calc_net_energy_lactation handles pigs", {
     animal = "PGS", cohort = "FA",
     milking_fraction = 0, milk_yield = 0, milk_fat = 0,
     idle = 0.2, gest = 0.3, litsize = 10, dr1 = 0.1, ckg = 1.5, wkg = 8,
-    lact = 0.5, parturition_rate = 2.2, lambing_interval = 365, assessment_duration = 365
+    lact = 0.5, parturition_rate = 2.2, lambing_interval = 400, weaning_age = 365
   )
   cadj <- 0.5 / (0.2 + 0.3 + 0.5)
   expected <- 10 * (1 - 0.5 * 0.1) * ((0.02059 * (8 - 1.5) * 1000 / 0.5) - (0.3766 / 0.67)) * cadj

--- a/tests/testthat/test-production_cohort_core.R
+++ b/tests/testthat/test-production_cohort_core.R
@@ -283,7 +283,7 @@ test_that("compute_fibre_output handles validation errors", {
 # ---- test compute_meat_outputs ----
 test_that("compute_meat_outputs returns expected output structure", {
   result <- compute_meat_outputs(
-    offtake_number = 10,
+    offtake_number_assessment = 10,
     slaughter_weight = 400,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.75,
@@ -302,44 +302,41 @@ test_that("compute_meat_outputs returns expected output structure", {
 
 test_that("compute_meat_outputs calculates liveweight correctly", {
   result <- compute_meat_outputs(
-    offtake_number = 50,
+    offtake_number_assessment = 50,
     slaughter_weight = 300,
     carcass_dressing_percentage = 0.60,
     bone_free_meat_fraction = 0.80,
-    meat_protein = 0.22,
-    assessment_duration = 200
+    meat_protein = 0.22
   )
 
-  expected_liveweight <- 50/365 * 200 * 300
+  expected_liveweight <- 50 * 300
   expect_equal(result$output_meat_production_liveweight, expected_liveweight)
 })
 
 test_that("compute_meat_outputs calculates carcass weight correctly", {
   result <- compute_meat_outputs(
-    offtake_number = 25,
+    offtake_number_assessment = 25,
     slaughter_weight = 450,
     carcass_dressing_percentage = 0.58,
     bone_free_meat_fraction = 0.78,
-    meat_protein = 0.21,
-    assessment_duration = 200
+    meat_protein = 0.21
   )
 
-  expected_liveweight <- 25/365 * 200 * 450
+  expected_liveweight <- 25 * 450
   expected_carcass <- expected_liveweight * 0.58
   expect_equal(result$output_meat_production_carcassweight, expected_carcass)
 })
 
 test_that("compute_meat_outputs calculates boneless meat correctly", {
   result <- compute_meat_outputs(
-    offtake_number = 30,
+    offtake_number_assessment = 30,
     slaughter_weight = 350,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.70,
-    meat_protein = 0.20,
-    assessment_duration = 200
+    meat_protein = 0.20
   )
 
-  expected_liveweight <- 30/365 * 200 * 350
+  expected_liveweight <- 30 * 350
   expected_carcass <- expected_liveweight * 0.55
   expected_meat <- expected_carcass * 0.70
   expect_equal(result$output_meat_production_meat, expected_meat)
@@ -347,15 +344,14 @@ test_that("compute_meat_outputs calculates boneless meat correctly", {
 
 test_that("compute_meat_outputs calculates meat protein correctly", {
   result <- compute_meat_outputs(
-    offtake_number = 20,
+    offtake_number_assessment = 20,
     slaughter_weight = 400,
     carcass_dressing_percentage = 0.56,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.23,
-    assessment_duration = 200
-  )
+    meat_protein = 0.23
+    )
 
-  expected_liveweight <- 20/365 * 200 * 400
+  expected_liveweight <- 20 * 400
   expected_carcass <- expected_liveweight * 0.56
   expected_meat <- expected_carcass * 0.75
   expected_protein <- expected_meat * 0.23
@@ -364,12 +360,11 @@ test_that("compute_meat_outputs calculates meat protein correctly", {
 
 test_that("compute_meat_outputs handles zero offtake", {
   result <- compute_meat_outputs(
-    offtake_number = 0,
+    offtake_number_assessment = 0,
     slaughter_weight = 400,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.20,
-    assessment_duration = 200
+    meat_protein = 0.20
   )
 
   expect_equal(result$output_meat_production_liveweight, 0)
@@ -380,12 +375,11 @@ test_that("compute_meat_outputs handles zero offtake", {
 
 test_that("compute_meat_outputs handles zero slaughter weight", {
   result <- compute_meat_outputs(
-    offtake_number = 10,
+    offtake_number_assessment = 10,
     slaughter_weight = 0,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.20,
-    assessment_duration = 200
+    meat_protein = 0.20
   )
 
   expect_equal(result$output_meat_production_liveweight, 0)
@@ -396,12 +390,11 @@ test_that("compute_meat_outputs handles zero slaughter weight", {
 
 test_that("compute_meat_outputs verifies sequential calculation chain", {
   result <- compute_meat_outputs(
-    offtake_number = 100,
+    offtake_number_assessment = 100,
     slaughter_weight = 300,
     carcass_dressing_percentage = 0.50,
     bone_free_meat_fraction = 0.80,
-    meat_protein = 0.25,
-    assessment_duration = 200
+    meat_protein = 0.25
   )
 
   # Verify the chain: liveweight -> carcass -> meat -> protein
@@ -418,50 +411,45 @@ test_that("compute_meat_outputs verifies sequential calculation chain", {
 test_that("compute_meat_outputs handles validation errors", {
   expect_error(
     compute_meat_outputs(
-      offtake_number = -10, slaughter_weight = 400,
+      offtake_number_assessment = -10, slaughter_weight = 400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = 0.75,
-      meat_protein = 0.20,
-      assessment_duration = 200
+      meat_protein = 0.20
     ),
-    "offtake_number"
+    "offtake_number_assessment"
   )
 
   expect_error(
     compute_meat_outputs(
-      offtake_number = 10, slaughter_weight = -400,
+      offtake_number_assessment = 10, slaughter_weight = -400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = 0.75,
-      meat_protein = 0.20,
-      assessment_duration = 200
+      meat_protein = 0.20
     ),
     "slaughter_weight"
   )
 
   expect_error(
     compute_meat_outputs(
-      offtake_number = 10, slaughter_weight = 400,
+      offtake_number_assessment = 10, slaughter_weight = 400,
       carcass_dressing_percentage = 1.5, bone_free_meat_fraction = 0.75,
-      meat_protein = 0.20,
-      assessment_duration = 200
+      meat_protein = 0.20
     ),
     "carcass_dressing_percentage"
   )
 
   expect_error(
     compute_meat_outputs(
-      offtake_number = 10, slaughter_weight = 400,
+      offtake_number_assessment = 10, slaughter_weight = 400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = -0.1,
-      meat_protein = 0.20,
-      assessment_duration = 200
+      meat_protein = 0.20
     ),
     "bone_free_meat_fraction"
   )
 
   expect_error(
     compute_meat_outputs(
-      offtake_number = 10, slaughter_weight = 400,
+      offtake_number_assessment = 10, slaughter_weight = 400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = 0.75,
-      meat_protein = 1.5,
-      assessment_duration = 200
+      meat_protein = 1.5
     ),
     "meat_protein"
   )

--- a/tests/testthat/test-production_cohort_core.R
+++ b/tests/testthat/test-production_cohort_core.R
@@ -287,7 +287,8 @@ test_that("compute_meat_outputs returns expected output structure", {
     slaughter_weight = 400,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.20
+    meat_protein = 0.20,
+    assessment_duration = 365
   )
 
   expect_type(result, "list")
@@ -305,10 +306,11 @@ test_that("compute_meat_outputs calculates liveweight correctly", {
     slaughter_weight = 300,
     carcass_dressing_percentage = 0.60,
     bone_free_meat_fraction = 0.80,
-    meat_protein = 0.22
+    meat_protein = 0.22,
+    assessment_duration = 200
   )
 
-  expected_liveweight <- 50 * 300
+  expected_liveweight <- 50/365 * 200 * 300
   expect_equal(result$output_meat_production_liveweight, expected_liveweight)
 })
 
@@ -318,10 +320,11 @@ test_that("compute_meat_outputs calculates carcass weight correctly", {
     slaughter_weight = 450,
     carcass_dressing_percentage = 0.58,
     bone_free_meat_fraction = 0.78,
-    meat_protein = 0.21
+    meat_protein = 0.21,
+    assessment_duration = 200
   )
 
-  expected_liveweight <- 25 * 450
+  expected_liveweight <- 25/365 * 200 * 450
   expected_carcass <- expected_liveweight * 0.58
   expect_equal(result$output_meat_production_carcassweight, expected_carcass)
 })
@@ -332,10 +335,11 @@ test_that("compute_meat_outputs calculates boneless meat correctly", {
     slaughter_weight = 350,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.70,
-    meat_protein = 0.20
+    meat_protein = 0.20,
+    assessment_duration = 200
   )
 
-  expected_liveweight <- 30 * 350
+  expected_liveweight <- 30/365 * 200 * 350
   expected_carcass <- expected_liveweight * 0.55
   expected_meat <- expected_carcass * 0.70
   expect_equal(result$output_meat_production_meat, expected_meat)
@@ -347,10 +351,11 @@ test_that("compute_meat_outputs calculates meat protein correctly", {
     slaughter_weight = 400,
     carcass_dressing_percentage = 0.56,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.23
+    meat_protein = 0.23,
+    assessment_duration = 200
   )
 
-  expected_liveweight <- 20 * 400
+  expected_liveweight <- 20/365 * 200 * 400
   expected_carcass <- expected_liveweight * 0.56
   expected_meat <- expected_carcass * 0.75
   expected_protein <- expected_meat * 0.23
@@ -363,7 +368,8 @@ test_that("compute_meat_outputs handles zero offtake", {
     slaughter_weight = 400,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.20
+    meat_protein = 0.20,
+    assessment_duration = 200
   )
 
   expect_equal(result$output_meat_production_liveweight, 0)
@@ -378,7 +384,8 @@ test_that("compute_meat_outputs handles zero slaughter weight", {
     slaughter_weight = 0,
     carcass_dressing_percentage = 0.55,
     bone_free_meat_fraction = 0.75,
-    meat_protein = 0.20
+    meat_protein = 0.20,
+    assessment_duration = 200
   )
 
   expect_equal(result$output_meat_production_liveweight, 0)
@@ -393,7 +400,8 @@ test_that("compute_meat_outputs verifies sequential calculation chain", {
     slaughter_weight = 300,
     carcass_dressing_percentage = 0.50,
     bone_free_meat_fraction = 0.80,
-    meat_protein = 0.25
+    meat_protein = 0.25,
+    assessment_duration = 200
   )
 
   # Verify the chain: liveweight -> carcass -> meat -> protein
@@ -412,7 +420,8 @@ test_that("compute_meat_outputs handles validation errors", {
     compute_meat_outputs(
       offtake_number = -10, slaughter_weight = 400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = 0.75,
-      meat_protein = 0.20
+      meat_protein = 0.20,
+      assessment_duration = 200
     ),
     "offtake_number"
   )
@@ -421,7 +430,8 @@ test_that("compute_meat_outputs handles validation errors", {
     compute_meat_outputs(
       offtake_number = 10, slaughter_weight = -400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = 0.75,
-      meat_protein = 0.20
+      meat_protein = 0.20,
+      assessment_duration = 200
     ),
     "slaughter_weight"
   )
@@ -430,7 +440,8 @@ test_that("compute_meat_outputs handles validation errors", {
     compute_meat_outputs(
       offtake_number = 10, slaughter_weight = 400,
       carcass_dressing_percentage = 1.5, bone_free_meat_fraction = 0.75,
-      meat_protein = 0.20
+      meat_protein = 0.20,
+      assessment_duration = 200
     ),
     "carcass_dressing_percentage"
   )
@@ -439,7 +450,8 @@ test_that("compute_meat_outputs handles validation errors", {
     compute_meat_outputs(
       offtake_number = 10, slaughter_weight = 400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = -0.1,
-      meat_protein = 0.20
+      meat_protein = 0.20,
+      assessment_duration = 200
     ),
     "bone_free_meat_fraction"
   )
@@ -448,7 +460,8 @@ test_that("compute_meat_outputs handles validation errors", {
     compute_meat_outputs(
       offtake_number = 10, slaughter_weight = 400,
       carcass_dressing_percentage = 0.55, bone_free_meat_fraction = 0.75,
-      meat_protein = 1.5
+      meat_protein = 1.5,
+      assessment_duration = 200
     ),
     "meat_protein"
   )


### PR DESCRIPTION
This PR reviews and updates the codebase to ensure consistent use of assessment_duration and to eliminate hard-coded assumptions of a 365-day assessment period.

**Energy requirements**

- The calc_net_energy_lactation() function was revised to improve consistency with the overall time-handling logic.
- The assessment_duration argument was removed and replaced with weaning_age, which more accurately reflects the biological process being modelled. Further details are provided in the commit message.

**Production & Allocation**

- The hard-coded default of 365 days was removed.
- The compute_meat_outputs() function was revised to align with the updated time-scaling approach.  --> Since offtake_number is defined on an annual basis, a method consistent with calculate_fibre_outputs() was adopted: offtake_number is converted to a daily rate (divided by 365) and then scaled by assessment_duration to estimate meat production over the assessment window.

Documentation and tests were updated to reflect these changes and ensure consistent behaviour.