### PR TITLE
Manure&N balance/Documentation enhancement + minor reviews

### DIFF
--- a/R/directemissions_manure_core_model.R
+++ b/R/directemissions_manure_core_model.R
@@ -14,28 +14,16 @@
 #' @return Numeric. Volatile solids (kg VS/head/day)
 #'
 #' @export
-calc_volatile_solids <- function(animal, lps_short, dmi, diet_dig, diet_me, diet_ge, ipcc_method) {
-  validate_manure_inputs(animal, lps_short, dmi, diet_dig, diet_me, diet_ge, ipcc_method)
+calc_volatile_solids <- function(animal, dmi, diet_dig, diet_me, diet_ge) {
+  validate_manure_inputs(animal, dmi, diet_dig, diet_me, diet_ge)
 
   # Row-by-row calculation (scalar values)
   if (animal %in% c("CTL", "BFL", "CML", "SHP", "GTS")) {
     # Case 1: CTL, BFL, CML, SHP, GTS
     vs <- dmi * (1.04 - diet_dig) * 0.92
-  } else if (animal == "PGS" && ipcc_method == "2019") {
+  } else if (animal == "PGS") {
     # Case 2: PGS (2019)
     vs <- dmi * (1.02 - diet_dig) * 0.94
-  } else if (animal == "PGS" && ipcc_method == "2006") {
-    # Case 2: PGS (2006)
-    vs <- dmi * (1.02 - diet_dig) * 0.8
-  } else if (animal == "CHK" && ipcc_method == "2006" && lps_short == "BRL") {
-    # Case 3: CHK 2006 BRL
-    vs <- dmi * (1 - diet_me / diet_ge) * 0.95
-  } else if (animal == "CHK" && ipcc_method == "2006" && lps_short != "BRL") {
-    # Case 3: CHK 2006 non-BRL
-    vs <- dmi * (1 - diet_me / diet_ge) * 0.89
-  } else if (animal == "CHK" && ipcc_method == "2019") {
-    # Case 3: CHK 2019
-    vs <- dmi * (1 - diet_me / diet_ge) * 0.70
   } else {
     vs <- 0
   }

--- a/R/directemissions_manure_core_model.R
+++ b/R/directemissions_manure_core_model.R
@@ -1,18 +1,61 @@
 #' Calculate Volatile Solids for Manure Emissions
 #'
-#' Calculates volatile solids (VS) production from animal feed intake and diet composition
-#' using IPCC methodology for different animal types and production systems.
+#' Computes daily volatile solids (VS) excretion in manure (kg VS/head/day).
+#' VS represents the total organic material excreted (biodegradable + non-biodegradable)
+#' and is required to proceed with the estimate of methane emissions from manure maanagement.
 #'
-#' @param animal Character. Animal type (CTL, BFL, CML, SHP, GTS, PGS, CHK)
-#' @param lps_short Character. Livestock production system
-#' @param dmi Numeric. Dry matter intake (kg/head/day)
-#' @param diet_dig Numeric. Diet digestibility (0-1)
-#' @param diet_me Numeric. Metabolizable energy content (MJ/kg DM)
-#' @param diet_ge Numeric. Gross energy content (MJ/kg DM)
-#' @param ipcc_method Character. IPCC method ('2006' or '2019')
 #'
-#' @return Numeric. Volatile solids (kg VS/head/day)
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#' @param dmi Numeric. Daily dry matter intake of feed (kg DM/head/day).
+#' @param diet_dig Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)
+#' @param diet_me Numeric. Average metabolizable energy content of the diet (MJ/kg DM).
+#' @param diet_ge Numeric. Average gross energy content of the diet (MJ/kg DM).
 #'
+#' @return Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).
+#' 
+#' @details
+#' The IPCC recommends estimating VS from feed intake and digestibility when
+#' country-specific average daily VS excretion rates are not available. The core relationship is
+#' given in **IPCC Equation 10.24 (Volatile solids excretion rates)**, which uses gross energy (GE)
+#' intake, digestibility (DE), urinary energy as a fraction of GE (UE·GE), ash fraction (ASH), and
+#' a conversion factor of 18.45 MJ/kg DM.
+#'
+#' **Implementation note (simplified coefficients).**
+#' This package uses simplified algebraic forms by species/method that are consistent with the
+#' structure of Eq. 10.24 under fixed/default assumptions for \eqn{UE} and \eqn{ASH}, and with
+#' digestibility supplied directly as a fraction (\code{diet_dig}). 
+#' 
+#' **Species/method branches**
+#' \itemize{
+#'   \item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
+#'     \code{vs = dmi * (1.04 - diet_dig) * 0.92}.
+#'     The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
+#'     of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi. 
+#'     Second, it is assumed that Urinary energy is 4% and the Ash content in feed is 8%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
+#'     }
+#'   \item \strong{Swine} (\code{"PGS"}):
+#'     \itemize{
+#'       \item \code{vs = dmi * (1.02 - diet_dig) * 0.94}.
+#'       It is assumed that urinary energy is 2% and the ash content in feed is 6% (based on IPCC, 2019). Therefore, GE × (GE + UE) becomes 1.02 and 1 – ASH becomes 0.94.
+#'     }
+#' }
+#'
+#'
+#'@references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.24.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.24.
 #' @export
 calc_volatile_solids <- function(animal, dmi, diet_dig, diet_me, diet_ge) {
   validate_manure_inputs(animal, dmi, diet_dig, diet_me, diet_ge)
@@ -67,25 +110,40 @@ calc_methane_conversion_factor <- function(
 }
 
 #' Calculate CH4 Emissions from Manure
+#' 
+#' Calculates **methane (CH4) emissions** attributable to manure management pathways using
+#' the IPCC Tier 2 framework. The computation follows the structure of IPCC
+#' Eq. 10.23 (CH\eqn{_4} emission factor from manure management), but expressed on
+#' a daily basis because \code{vs} is provided as kg VS/head/day.
+#' 
+#' This function expects that methane conversion factors 
+#' (\code{mcf_pasture}, \code{mcf_burned}, \code{mcf_other}) are provided as
+#' **weighted fractions**, i.e. they have already been multiplied by the relative manure management system shares (mms)
 #'
-#' Calculates methane emissions from manure management systems using volatile solids,
-#' methane conversion factors, and maximum methane producing capacity (B0).
-#'
-#' @param vs Numeric vector of volatile solids (kg VS/head/day)
-#' @param mcf_pasture Numeric vector of methane conversion factor for pasture (dimensionless)
-#' @param mcf_burned Numeric vector of methane conversion factor for burned (dimensionless)
-#' @param mcf_other Numeric vector of methane conversion factor for other systems (dimensionless)
-#' @param b0_mms_all Numeric vector of maximum methane producing capacity for all systems (m³ CH4/kg VS)
-#' @param b0_mms_pasture Numeric vector of maximum methane producing capacity for pasture (m³ CH4/kg VS)
-#' @param ratio_m3CH4_kgCH4 Numeric. Conversion factor from m³ CH4 to kg CH4. Defaults to 0.67.
+#' @param vs Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).
+#' @param mcf_pasture Numeric. Effective methane conversion factor for manure deposited on pasture (mcfpasture), expressed in percent (%), and already weighted by the share of manure deposited on pasture (mmspasture) (percentage)
+#' @param mcf_burned Numeric. Effective methane conversion factor for manure burned for fuel (mcfburned), expressed in percent (%), and already weighted by the share of manure burned for fuel (mmsburned) (percentage)
+#' @param mcf_other Numeric. Effective methane conversion factor for manure managed in non-pasture, non-burned manure management systems, expressed in percent (%), and already weighted by the share of each corresponding manure management system (e.g., mmsolid, mmsliquid...etc.) (percentage)
+#' @param b0_mms_all Numeric. Maximum methane producing capacity for all systems (m³ CH4/kg VS). The value should is region- and species-specific. Default can be selected from Table 10.16 (IPCC, 2019) or from Tables 10A-4 to 10A-9 (IPCC, 2006)
+#' @param b0_mms_pasture Numeric. Maximum methane producing capacity for manure deposited on pasture (m³ CH4/kg VS). Default can be selected from Table 10.16 (IPCC, 2019). For IPCC 2006 method, it is assumed to be equal to b0_mms_all.
+#' @param ratio_m3CH4_kgCH4 Numeric. Conversion factor from m³ CH4 to kg CH4. Default to 0.67.
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{ch4_manure_pasture}{CH4 emissions from pasture (kg CH4/head/day)}
-#'   \item{ch4_manure_burned}{CH4 emissions from burned manure (kg CH4/head/day)}
-#'   \item{ch4_manure_other}{CH4 emissions from other systems (kg CH4/head/day)}
-#'   \item{ch4_manure_all_noburn}{Total CH4 emissions excluding burned (kg CH4/head/day)}
+#'   \item{ch4_manure_pasture}{Numeric. Methane emissions from manure deposited on pasture (kg CH4/head/day))}
+#'   \item{ch4_manure_burned}{Numeric. Methane emissions from manure burned for fuel (kg CH4/head/day)}
+#'   \item{ch4_manure_other}{Numeric. Methane emissions from manure managed in all other manure management systems, excluding emissions from manure deposired on pasture and burned (kg CH4/head/day)}
+#'   \item{ch4_manure_all_noburn}{Numeric. Methane emissions from manure managed in all other manure management systems and deposited on pasture, excluding emissions from burned manure (kg CH4/head/day)}
 #' }
+#'
+#'@details
+#'
+#'@references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.23.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.23.
 #'
 #' @export
 calc_ch4_emissions <- function(
@@ -112,35 +170,50 @@ calc_ch4_emissions <- function(
 
 #' Calculate Direct N2O Emissions from Manure
 #'
-#' Calculates direct nitrous oxide emissions from manure management systems
-#' using nitrogen excretion and EF3 emission factors.
+#' Calculates **direct nitrous oxide (N2O)** emissions from manure management
+#' pathways using the IPCC Tier 2 framework. The calculation follows the structure of
+#' IPCC Eq. 10.25 (direct N2O emissions from manure management), but is expressed
+#' on a **daily basis** because \code{n_excretion} is provided in
+#' kg N/head/day.
 #'
-#' @param n_excretion Numeric vector of nitrogen excretion (kg N/head/day)
-#' @param ef3_pasture Numeric vector of EF3 emission factor for pasture (kg N2O-N/kg N)
-#' @param ef3_burned Numeric vector of EF3 emission factor for burned (kg N2O-N/kg N)
-#' @param ef3_other Numeric vector of EF3 emission factor for other systems (kg N2O-N/kg N)
-#' @param ratio_N2O_N2ON Numeric. Conversion factor from kg N2O-N to kg N2O. Defaults to 44/28.
+#' This function expects that the emission-factor inputs
+#' (\code{ef3_pasture}, \code{ef3_burned}, \code{ef3_other}) are provided as
+#' **effective (already weighted) factors**, i.e. they have already been
+#' multiplied by the corresponding manure management system shares (mms).
+#'
+#' @param n_excretion Numeric. Daily nitrogen excretion (kg N/head/day)
+#' @param ef3_pasture Numeric. Effective EF3 factor for manure deposited on pasture (ef3pasture), expressed in kg N2O-N / kg N excreted, and already weighted by the share of manure deposited on pasture (mmspasture) (kg N2O-N / kg N excreted)
+#' @param ef3_burned Numeric. Effective EF3 factor for manure burned for fuel (ef3burned), expressed in kg N2O-N / kg N excreted, and already weighted by the share of manure burned for fuel (mmsburned) (kg N2O-N / kg N excreted)
+#' @param ef3_other Numeric. Effective EF3 factor for manure managed in non-pasture, non-burned manure management systems, expressed in g N2O-N / kg N excreted, and already weighted by the share of each corresponding manure management system (e.g., mmsolid, mmsliquid...etc.) (kg N2O-N / kg N excreted)
+#' @param ration_N2ON_to_N2O Numeric. Conversion factor from kg N2O-N to kg N2O. Default to 44/28.
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{direct_n2o_manure_pasture}{Direct N2O emissions from pasture (kg N2O/head/day)}
-#'   \item{direct_n2o_manure_burned}{Direct N2O emissions from burned manure (kg N2O/head/day)}
-#'   \item{direct_n2o_manure_other}{Direct N2O emissions from other systems (kg N2O/head/day)}
-#'   \item{direct_n2o_manure_all_noburn}{Total direct N2O emissions excluding burned (kg N2O/head/day)}
+#'   \item{direct_n2o_manure_pasture}{Numeric. Direct nitrous oxide emissions from manure deposited on pasture (kg N2O/head/day)}
+#'   \item{direct_n2o_manure_burned}{Numeric. Direct nitrous oxide emissions from manure burned for fuel (kg N2O/head/day)}
+#'   \item{direct_n2o_manure_other}{Numeric. Direct nitrous oxide emissions from manure managed in all other manure management systems, excluding emissions from manure deposired on pasture and burned (kg N2O/head/day)}
+#'   \item{direct_n2o_manure_all_noburn}{Numeric. Direct nitrous oxide emissions from manure managed in all other manure management systems and deposited on pasture, excluding emissions from burned manure (kg N2O/head/day)}
 #' }
 #'
+#' @references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.25.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.25.
+#' 
 #' @export
 calc_direct_n2o_emissions <- function(
     n_excretion,
     ef3_pasture,
     ef3_burned,
     ef3_other,
-    ratio_N2O_N2ON = 44/28
+    ration_N2ON_to_N2O = 44/28
 ) {
   validate_direct_n2o_inputs(n_excretion, ef3_pasture, ef3_burned, ef3_other)
-  n2o_pasture <- n_excretion * ef3_pasture * ratio_N2O_N2ON
-  n2o_burned <- n_excretion * ef3_burned * ratio_N2O_N2ON
-  n2o_other <- n_excretion * ef3_other * ratio_N2O_N2ON
+  n2o_pasture <- n_excretion * ef3_pasture * ration_N2ON_to_N2O
+  n2o_burned <- n_excretion * ef3_burned * ration_N2ON_to_N2O
+  n2o_other <- n_excretion * ef3_other * ration_N2ON_to_N2O
   n2o_all_noburn <- n2o_pasture + n2o_other
   return(list(
     direct_n2o_manure_pasture = n2o_pasture,
@@ -193,22 +266,36 @@ calc_nitrogen_volatilization_fraction <- function(
 
 #' Calculate Nitrogen Volatilization
 #'
-#' Calculates nitrogen lost via volatilization from manure management systems
-#' using nitrogen excretion and volatilization fractions.
+#' Computes nitrogen lost through volatilization as NH3 and NOx from manure
+#' management pathways. The calculation follows the IPCC structure
+#' (Eq. 10.26), but is expressed on a **daily** basis because \code{n_excretion}
+#' is provided in kg N/head/day.
 #'
-#' @param n_excretion Numeric vector of nitrogen excretion (kg N/head/day)
-#' @param fracgas_pasture Numeric vector of volatilization fraction for pasture (0-1)
-#' @param fracgas_burned Numeric vector of volatilization fraction for burned (0-1)
-#' @param fracgas_other Numeric vector of volatilization fraction for other systems (0-1)
+#' This function expects volatilization fractions
+#' (\code{fracgas_pasture}, \code{fracgas_burned}, \code{fracgas_other}) to be provided as
+#' **effective (already weighted)** fractions, i.e. each fraction has already
+#' been multiplied by the corresponding manure management system share (mms).
+#'
+#' @param n_excretion Numeric. Daily nitrogen excretion (kg N/head/day)
+#' @param fracgas_pasture Numeric. Effective fraction of excreted nitrogen volatilized as NH₃ and NOₓ from manure deposited on pasture, already weighted by the share of manure deposited on pasture (mmspasture) (fraction).
+#' @param fracgas_burned Numeric. Effective fraction of excreted nitrogen volatilized as NH₃ and NOₓ from manure burned for fuel, already weighted by the share of manure burned (mmsburned) (fraction).
+#' @param fracgas_other Numeric. Effective fraction of excreted nitrogen volatilized as NH₃ and NOₓ from manure managed in non-pasture, non-burned manure management systems, already weighted by the shares of the corresponding systems (fraction).
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{n_vol_manure_pasture}{Nitrogen volatilized from pasture (kg N/head/day)}
-#'   \item{n_vol_manure_burned}{Nitrogen volatilized from burned manure (kg N/head/day)}
-#'   \item{n_vol_manure_other}{Nitrogen volatilized from other systems (kg N/head/day)}
-#'   \item{n_vol_manure_all_noburn}{Total nitrogen volatilized excluding burned (kg N/head/day)}
+#'   \item{n_vol_manure_pasture}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure deposited on pasture (kg N/head/day)}
+#'   \item{n_vol_manure_burned}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure burned for fuel (kg N/head/day)}
+#'   \item{n_vol_manure_other}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure managed in all other systems, excluding losses from manure deposited on pasture and burned for fuel (kg N/head/day)}
+#'   \item{n_vol_manure_all_noburn}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure managed in all other systems and deposited on pasture, excluding losses from manure burned for fuel (kg N/head/day)}
 #' }
 #'
+#' @references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.26.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.26.
+#' 
 #' @export
 calc_nitrogen_volatilization <- function(
     n_excretion,
@@ -231,21 +318,31 @@ calc_nitrogen_volatilization <- function(
 
 #' Calculate N2O Emissions from Nitrogen Volatilization
 #'
-#' Calculates nitrous oxide emissions from volatilized nitrogen using EF4 emission factors.
+#' Converts volatilized manure nitrogen (NH\eqn{_3} and NO\eqn{_x}) into indirect
+#' nitrous oxide (N\eqn{_2}O) emissions using the IPCC emission factor \code{EF4}.
 #'
-#' @param n_vol_pasture Numeric vector of nitrogen volatilized from pasture (kg N/head/day)
-#' @param n_vol_burned Numeric vector of nitrogen volatilized from burned manure (kg N/head/day)
-#' @param n_vol_other Numeric vector of nitrogen volatilized from other systems (kg N/head/day)
-#' @param ef4 Numeric vector of EF4 emission factor (kg N2O-N/kg N)
-#' @param ratio_N2O_N2ON Numeric. Conversion factor from kg N2O-N to kg N2O. Defaults to 44/28.
+#' The calculation is implemented on a **daily basis** because volatilized nitrogen
+#' inputs are provided as kg N/head/day.
+#'
+#' @param n_vol_pasture Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure deposited on pasture (kg N/head/day).
+#' @param n_vol_burned Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure burned for fuel (kg N/head/day).
+#' @param n_vol_other "Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure managed in all other systems, excluding losses from manure deposited on pasture and burned for fuel (kg N/head/day).
+#' @param ef4 Numeric. Emission factor for indirect nitrous oxide (N₂O) emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃–N and NOₓ–N) onto soils and water surfaces (kg N₂O–N / (kg NH₃–N + NOₓ–N)).
+#' @param ration_N2ON_to_N2O Numeric. Conversion factor from kg N2O-N to kg N2O. Default to 44/28
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{n2o_vol_manure_pasture}{N2O emissions from volatilized nitrogen from pasture (kg N2O/head/day)}
-#'   \item{n2o_vol_manure_burned}{N2O emissions from volatilized nitrogen from burned manure (kg N2O/head/day)}
-#'   \item{n2o_vol_manure_other}{N2O emissions from volatilized nitrogen from other systems (kg N2O/head/day)}
-#'   \item{n2o_vol_manure_all_noburn}{Total N2O emissions from volatilization excluding burned (kg N2O/head/day)}
+#'   \item{n2o_vol_manure_pasture}{Numeric. Indirect nitrous oxide emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure deposited on pasture (kg N2O/head/day)}
+#'   \item{n2o_vol_manure_burned}{Numeric. Indirect nitrous oxide emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure burned for fuel (kg N2O/head/day)}
+#'   \item{n2o_vol_manure_other}{Numeric. Indirect nitrous oxide (N₂O) emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure managed in all other manure management systems, excluding manure deposited on pasture and manure burned for fuel (kg N2O/head/day)}
+#'   \item{n2o_vol_manure_all_noburn}{Numeric. Indirect nitrous oxide (N₂O) emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure managed in all non-burned manure management systems, including manure deposited on pasture (kg N2O/head/day)}
 #' }
+#' @references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.28.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.28.
 #'
 #' @export
 calc_n2o_from_volatilization <- function(
@@ -253,12 +350,12 @@ calc_n2o_from_volatilization <- function(
     n_vol_burned,
     n_vol_other,
     ef4,
-    ratio_N2O_N2ON = 44/28
+    ration_N2ON_to_N2O = 44/28
 ) {
   validate_n2o_volatilization_inputs(n_vol_pasture, n_vol_burned, n_vol_other, ef4)
-  n2o_pasture <- n_vol_pasture * ef4 * ratio_N2O_N2ON
-  n2o_burned <- n_vol_burned * ef4 * ratio_N2O_N2ON
-  n2o_other <- n_vol_other * ef4 * ratio_N2O_N2ON
+  n2o_pasture <- n_vol_pasture * ef4 * ration_N2ON_to_N2O
+  n2o_burned <- n_vol_burned * ef4 * ration_N2ON_to_N2O
+  n2o_other <- n_vol_other * ef4 * ration_N2ON_to_N2O
   n2o_all_noburn <- n2o_pasture + n2o_other
   return(list(
     n2o_vol_manure_pasture = n2o_pasture,
@@ -311,22 +408,36 @@ calc_nitrogen_leaching_fraction <- function(
 
 #' Calculate Nitrogen Leaching
 #'
-#' Calculates nitrogen lost via leaching from manure management systems
-#' using nitrogen excretion and leaching fractions.
+#' Calculates the amount of manure nitrogen lost via **leaching and runoff**
+#' from manure management systems (kg N/head/day). This follows the IPCC
+#' structure of Eq. 10.27, but expressed on a **daily** basis because
+#' \code{n_excretion} is provided in kg N/head/day.
+#' 
+#' The function assumes leaching/runoff fractions - (\code{fracleach_pasture}, \code{fracleach_burned}, \code{fracleach_other}) -
+#' are provided as **effective
+#' weighted fractions**, i.e. they have already been multiplied by the
+#' corresponding manure management system shares (mms fractions).
 #'
-#' @param n_excretion Numeric vector of nitrogen excretion (kg N/head/day)
-#' @param fracleach_pasture Numeric vector of leaching fraction for pasture (0-1)
-#' @param fracleach_burned Numeric vector of leaching fraction for burned (0-1)
-#' @param fracleach_other Numeric vector of leaching fraction for other systems (0-1)
+#' @param n_excretion Numeric. Daily nitrogen excretion (kg N/head/day)
+#' @param fracleach_pasture Numeric. Effective fraction of excreted nitrogen lost through leaching and runoff from manure deposited on pasture, already weighted by the share of manure deposited on pasture (mmspasture) (fraction).
+#' @param fracleach_burned Numeric. Effective fraction of excreted nitrogen lost through leaching and runoff from manure burned for fuel, already weighted by the share of manure burned (mmsburned) (fraction).
+#' @param fracleach_other Numeric. Effective fraction of excreted nitrogen lost through leaching and runoff from manure managed in non-pasture, non-burned manure management systems, already weighted by the shares of the corresponding manure management systems (e.g. solid storage, drylot, liquid/slurry) (fraction).
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{n_leach_manure_pasture}{Nitrogen leached from pasture (kg N/head/day)}
-#'   \item{n_leach_manure_burned}{Nitrogen leached from burned manure (kg N/head/day)}
-#'   \item{n_leach_manure_other}{Nitrogen leached from other systems (kg N/head/day)}
-#'   \item{n_leach_manure_all_noburn}{Total nitrogen leached excluding burned (kg N/head/day)}
+#'   \item{n_leach_manure_pasture}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure deposited on pasture (kg N/head/day).}
+#'   \item{n_leach_manure_burned}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure burned for fuel (kg N/head/day).}
+#'   \item{n_leach_manure_other}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure managed in all other systems, excluding losses from manure deposited on pasture and manure burned for fuel (kg N/head/day).}
+#'   \item{n_leach_manure_all_noburn}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure managed in all other systems and deposited on pasture, excluding losses from manure burned for fuel (kg N/head/day).}
 #' }
 #'
+#' @references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.27.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.27.
+#' 
 #' @export
 calc_nitrogen_leaching <- function(
     n_excretion,
@@ -349,34 +460,47 @@ calc_nitrogen_leaching <- function(
 
 #' Calculate N2O Emissions from Nitrogen Leaching
 #'
-#' Calculates nitrous oxide emissions from leached nitrogen using EF5 emission factors.
+#' Converts leached/runoff manure nitrogen losses (kg N/head/day) into indirect
+#' nitrous oxide (N\eqn{_2}O) emissions using the emission factor \code{ef5}
+#' (kg N2O-N per kg N leached/runoff), consistent with the IPCC framework
+#' for indirect N2O from leaching/runoff. 
 #'
-#' @param n_leach_pasture Numeric vector of nitrogen leached from pasture (kg N/head/day)
-#' @param n_leach_burned Numeric vector of nitrogen leached from burned manure (kg N/head/day)
-#' @param n_leach_other Numeric vector of nitrogen leached from other systems (kg N/head/day)
-#' @param ef5 Numeric vector of EF5 emission factor (kg N2O-N/kg N)
-#' @param ratio_N2O_N2ON Numeric. Conversion factor from kg N2O-N to kg N2O. Defaults to 44/28.
+#' The calculation is implemented on a **daily basis** because volatilized nitrogen
+#' inputs are provided as kg N/head/day.
+#' 
+#' @param n_leach_pasture Numeric. Amount of manure nitrogen lost through leaching and runoff from manure deposited on pasture (kg N/head/day).
+#' @param n_leach_burned Numeric. Amount of manure nitrogen lost through leaching and runoff from manure burned for fuel (kg N/head/day).
+#' @param n_leach_other Numeric. Amount of manure nitrogen lost through leaching and runoff from manure managed in all other systems, excluding losses from manure deposited on pasture and manure burned for fuel (kg N/head/day).
+#' @param ef5 Numeric. Emission factor for indirect nitrous oxide emissions resulting from nitrogen leaching and runoff, expressed as kilograms of N₂O–N per kilogram of nitrogen leached or lost through runoff (kg N₂O–N / kg N leached and runoff).
+#' @param ration_N2ON_to_N2O Numeric. Conversion factor from kg N2O-N to kg N2O. Default to 44/28.
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{n2o_leach_manure_pasture}{N2O emissions from leached nitrogen from pasture (kg N2O/head/day)}
-#'   \item{n2o_leach_manure_burned}{N2O emissions from leached nitrogen from burned manure (kg N2O/head/day)}
-#'   \item{n2o_leach_manure_other}{N2O emissions from leached nitrogen from other systems (kg N2O/head/day)}
-#'   \item{n2o_leach_manure_all_noburn}{Total N2O emissions from leaching excluding burned (kg N2O/head/day)}
+#'   \item{n2o_leach_manure_pasture}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from manure deposited on pasture (kg N₂O/head/day).}
+#'   \item{n2o_leach_manure_burned}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from manure burned for fuel (kg N₂O/head/day).}
+#'   \item{n2o_leach_manure_other}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from manure managed in all other systems, excluding manure deposited on pasture and manure burned for fuel (kg N₂O/head/day).}
+#'   \item{n2o_leach_manure_all_noburn}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from all non-burned manure management systems, including manure deposited on pasture (kg N₂O/head/day).}
 #' }
 #'
+#'#' @references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.29.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.29.
+#' 
 #' @export
 calc_n2o_from_leaching <- function(
     n_leach_pasture,
     n_leach_burned,
     n_leach_other,
     ef5,
-    ratio_N2O_N2ON = 44/28
+    ration_N2ON_to_N2O = 44/28
 ) {
   validate_n2o_leaching_inputs(n_leach_pasture, n_leach_burned, n_leach_other, ef5)
-  n2o_pasture <- n_leach_pasture * ef5 * ratio_N2O_N2ON
-  n2o_burned <- n_leach_burned * ef5 * ratio_N2O_N2ON
-  n2o_other <- n_leach_other * ef5 * ratio_N2O_N2ON
+  n2o_pasture <- n_leach_pasture * ef5 * ration_N2ON_to_N2O
+  n2o_burned <- n_leach_burned * ef5 * ration_N2ON_to_N2O
+  n2o_other <- n_leach_other * ef5 * ration_N2ON_to_N2O
   n2o_all_noburn <- n2o_pasture + n2o_other
   return(list(
     n2o_leach_manure_pasture = n2o_pasture,
@@ -388,8 +512,9 @@ calc_n2o_from_leaching <- function(
 
 #' Calculate Total N2O Emissions from Manure
 #'
-#' Calculates total nitrous oxide emissions (direct + indirect) from manure management systems.
-#'
+#' The function aggregates **direct** and **indirect** nitrous oxide emissions attributable to
+#' manure management, expressed on a **head/day** basis.
+#' 
 #' @param direct List containing direct N2O emissions with elements:
 #'   direct_n2o_manure_pasture, direct_n2o_manure_burned, direct_n2o_manure_other
 #' @param vol List containing N2O emissions from volatilization with elements:
@@ -399,12 +524,12 @@ calc_n2o_from_leaching <- function(
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{indirect_n2o_manure_pasture}{Indirect N2O emissions from pasture (kg N2O/head/day)}
-#'   \item{indirect_n2o_manure_burned}{Indirect N2O emissions from burned manure (kg N2O/head/day)}
-#'   \item{indirect_n2o_manure_other}{Indirect N2O emissions from other systems (kg N2O/head/day)}
-#'   \item{total_n2o_manure_pasture}{Total N2O emissions from pasture (kg N2O/head/day)}
-#'   \item{total_n2o_manure_burned}{Total N2O emissions from burned manure (kg N2O/head/day)}
-#'   \item{total_n2o_manure_other}{Total N2O emissions from other systems (kg N2O/head/day)}
+#'   \item{indirect_n2o_manure_pasture}{Numeric. Total indirect nitrous oxide (emissions originating from manure deposited on pasture, including emissions from atmospheric deposition of volatilised nitrogen (NH₃ and NOₓ) and from leaching and runoff of manure nitrogen (kg N₂O/head/day).}
+#'   \item{indirect_n2o_manure_burned}{Numeric. Total indirect nitrous oxide emissions originating from manure burned for fuel, including emissions from atmospheric deposition of volatilised nitrogen (NH₃ and NOₓ) and from leaching and runoff of manure nitrogen (kg N₂O/head/day).}
+#'   \item{indirect_n2o_manure_other}{Numeric. Total indirect nitrous oxide emissions originating from manure managed in all other manure management systems, excluding manure deposited on pasture and manure burned for fuel, including emissions from atmospheric deposition of volatilised nitrogen (NH₃ and NOₓ) and from leaching and runoff of manure nitrogen}
+#'   \item{total_n2o_manure_pasture}{Numeric. Total nitrous oxide emissions from manure deposited on pasture, including direct emissions and indirect emissions from volatilisation, leaching, and runoff (kg N₂O/head/day).}
+#'   \item{total_n2o_manure_burned}{Numeric. Total nitrous oxide emissions from manure burned for fuel, including direct emissions and indirect emissions from volatilisation, leaching, and runoff (kg N₂O/head/day).}
+#'   \item{total_n2o_manure_other}{Numeric. Total nitrous oxide emissions from manure managed in all other manure management systems, excluding manure deposited on pasture and manure burned for fuel, including direct emissions and indirect emissions from volatilisation, leaching, and runoff (kg N₂O/head/day).}
 #' }
 #'
 #' @export

--- a/R/nitrogen_balance_core_model.R
+++ b/R/nitrogen_balance_core_model.R
@@ -208,7 +208,7 @@ compute_nitrogen_retention <- function(
 #' @return Numeric. Daily nitrogen excretion (kg N/head/day).
 #' 
 #' @references
-# IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
 #' Livestock and Manure Management. Equation 10.31A.
 #' 
 #' @export

--- a/R/nitrogen_balance_core_model.R
+++ b/R/nitrogen_balance_core_model.R
@@ -1,12 +1,19 @@
 #' Compute Daily Nitrogen Intake
 #'
-#' Calculates nitrogen intake as the product of dry matter intake (DMI) and diet nitrogen content.
-#' This represents the gross nitrogen consumed per head per day.
+#' Calculates the daily nitrogen intake per head as the product of dry matter intake (DMI) and diet nitrogen content.
+#' The approach follows the Tier 2 IPCC guidelines (IPCC 2006, 2019). 
 #'
-#' @param dmi Numeric. Dry matter intake of feed (kg DM/head/day).
-#' @param diet_nitrogen Numeric. Nitrogen content per kg of feed dry matter intake (kg N/kg DM).
+#' @param dmi Numeric. Daily dry matter intake of feed (kg DM/head/day).
+#' @param diet_nitrogen Numeric. Average nitrogen content of diet (kg N/kg DM).
 #'
-#' @return Numeric. Daily nitrogen intake (kg N/head/day).
+#' @return Numeric. Daily nitrogen intake (kg N/head/day)
+#'
+#'@references
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.32.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.32.
 #'
 #' @export
 compute_nitrogen_intake <- function(dmi, diet_nitrogen) {
@@ -17,25 +24,109 @@ compute_nitrogen_intake <- function(dmi, diet_nitrogen) {
 
 #' Compute Daily Nitrogen Retention
 #'
-#' Calculates nitrogen retention by species and cohort. Retention includes nitrogen
-#' retained in milk, growth, and fibre (for ruminants only), and in growth and reproductive processes (for pigs only).
-#' Chickens are not implemented yet and return `NA`.
+#' Calculates daily nitrogen retention per animal by species and cohort.
+#' Nitrogen retention represents the portion of consumed nitrogen that is
+#' incorporated into animal products or body tissues.
+#' The approach follows the Tier 2 IPCC guidelines (IPCC 2006, 2019).
 #'
-#' @param animal Character. Species code (e.g., "PGS", "CML", "CTL", "BFL", "SHP", "GTS").
-#' @param cohort Character. Cohort code (e.g., "FJ", "MJ", "FS", "MS", "FA", "MA").
-#' @param milk_protein Numeric. Milk protein content (fraction), used to derive milk nitrogen.
-#' @param milk_yield Numeric. Milk yield (kg/head/day).
-#' @param dwg Numeric. Daily weight gain (kg/head/day).
-#' @param fibre_prod Numeric. Production yield of fibre, such as wool, cashmere, mohair (kg/head/year).
-#' @param litsize Numeric. Litter size (mean number of offspring per parturition).
-#' @param parturition_rate Numeric. Annual parturition rate of adult females (parturitions/head/year).
-#' @param wkg Numeric. Weaning weight (kg).
-#' @param ckg Numeric. Birth weight (kg).
-#' @param afc Numeric. Age at first parturition (years).
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#' @param cohort "Character. Sex- and age-specific cohort code describing the
+#'   production stage of the animals. Supported values include:
+#'   \itemize{
+#'     \item \code{FA}: adult females (from age at first parturition)
+#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
+#'     \item \code{FJ}: juvenile females (from birth to weaning)
+#'     \item \code{MA}: adult males (from age at first breeding)
+#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
+#'     \item \code{MJ}: juvenile males (from birth to weaning)
+#'   }
+#' @param milk_protein Numeric. Milk protein fraction (kg protein / kg milk).
+#' @param milk_yield Numeric. Average milk yield per milk-producing animal during the assessment duration (kg/head/day). This value can be calculated by dividing the total milk destinated to human consumption produced per milk-producing animal over the assessment duration by the length of the assessment period.
+#' @param dwg Numeric. Average live weight of the cohort over the cohort stage (kg/head/day).
+#' @param fibre_prod Numeric. Annual production yield of fibre, such as wool, cashmere, mohair (kg/head/year).
+#' @param litsize Numeric. Average number of offspring born per parturition (#). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.
+#' @param parturition_rate Numeric. Numeric. Average annual number of parturitions per female animal (fraction). At herd level, calculated as offspring delivered divided by the number of adult females.
+#' @param wkg Numeric. Live weight of the animal at weaning (kg)
+#' @param ckg Numeric. Live weight of the animal at birth (kg).
+#' @param afc Numeric. Age at first parturition for female breeding animals (years)
 #'
-#' @return Numeric. Daily nitrogen retention (kg N/head/day).
+#' @return Numeric.  Daily nitrogen retention in animal body tissues and products (e.g., growth, pregnancy, milk...) (kg N/head/day)
+#' 
+#' @details
+#' Species-specific calculations are performed.
 #'
+#' ## Ruminants and camelids (CTL, BFL, SHP, GTS, CML)
+#' For ruminants and camelids, nitrogen retained in products and tissues is
+#' computed consistent with the process described in the Technical paper
+#' from MPI (Ministry for Primary Industries (MPI), 2025).
+#'
+#' Nitrogen retention is calculated as the sum of:
+#' \itemize{
+#'   \item nitrogen secreted in milk,
+#'   \item nitrogen retained in liveweight gain (tissue),
+#'   \item nitrogen retained in fibre (for fibre-producing species).
+#' }
+#'
+#' Coefficients for nitrogen content of deposited tissue, fibre, and milk are
+#' derived from Chapter 5 (Nitrogen excretion) of the MPI inventory methodology.
+#'
+#' The following constants are used:
+#' \itemize{
+#'   \item \strong{Tissue nitrogen content (\code{tissue_n})}:
+#'     \itemize{
+#'       \item Cattle (\code{CTL}, \code{BFL}): \strong{0.0326 kg N per kg live weight}
+#'       \item Sheep (\code{SHP}), goats (\code{GTS}) and camelids (\code{CML}):
+#'       \strong{0.026 kg N per kg live weight}
+#'     }
+#'   \item \strong{Fibre nitrogen content (\code{fibre_n})}:
+#'   \strong{0.134 kg N per kg fibre}
+#'   \item \strong{Milk nitrogen content}:
+#'   Milk nitrogen is derived from milk protein using a protein-to-nitrogen
+#'   conversion factor of \strong{6.25}
+#' }
+#'
+#' ## Pigs (PGS)
+#' For pigs, nitrogen retention is calculated following the IPCC 2019 equations
+#' for swine (Equations 10.33A and 10.33B).
+#'
+#' Nitrogen retention includes nitrogen retained in:
+#' \itemize{
+#'   \item body growth,
+#'   \item reproductive outputs (conceptus and weaned offspring).
+#' }
+#'
+#' Calculations are expressed on a daily basis. In this implementation:
+#' \itemize{
+#'   \item \code{0.025} represents the nitrogen content of liveweight gain
+#'   (kg N per kg gain),
+#'   \item \code{0.98} is the protein digestibility fraction,
+#'   \item breeding cohorts include an annual reproductive component that is
+#'   converted to a daily rate.
+#' }
+#'
+#'@references
+#' Ministry for Primary Industries (MPI). (2025).
+#' \emph{Detailed methodologies for agricultural greenhouse gas emission calculation:
+#' Methodology for calculation of New Zealand’s agricultural greenhouse gas emissions}
+#' (Version 11). MPI Technical Paper, Wellington, New Zealand. Chapter 5.
+#' 
+#' IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.33A, 10.33B.
+#'
+#' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.33.
+#' 
 #' @export
+
 compute_nitrogen_retention <- function(
     animal,
     cohort,
@@ -91,16 +182,35 @@ compute_nitrogen_retention <- function(
 }
 
 #' Compute Daily Nitrogen Excretion
+#' 
+#' Calculates daily nitrogen excretion per animal (kg N/head/day) as the difference between
+#' nitrogen intake and nitrogen retention.
 #'
-#' Calculates nitrogen excretion (kg N/head/day) as the difference between
-#' nitrogen intake and retention for applicable species.
+#' Nitrogen excretion represents the fraction of consumed nitrogen that is not
+#' retained in animal products or body tissues and is therefore excreted in urine
+#' and dung. This quantity forms the basis for subsequent calculations of
+#' nitrous oxide (N2O) emissions from manure management and agricultural soils.
+#' The approach follows the Tier 2 IPCC guidelines.
 #'
-#' @param animal Character. Species code (e.g., "PGS", "CML", "CTL", "BFL", "SHP", "GTS").
-#' @param n_intake Numeric. Nitrogen intake (kg N/head/day).
-#' @param n_retention Numeric. Nitrogen retention (kg N/head/day).
+#' @param animal Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'   }
+#' @param n_intake Numeric. Daily nitrogen intake (kg N/head/day)
+#' @param n_retention Numeric.  Daily nitrogen retention in animal body tissues and products (e.g., growth, pregnancy, milk...) (kg N/head/day)
 #'
 #' @return Numeric. Daily nitrogen excretion (kg N/head/day).
-#'
+#' 
+#' @references
+# IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+#' Livestock and Manure Management. Equation 10.31A.
+#' 
 #' @export
 compute_nitrogen_excretion <- function(
     animal,

--- a/R/nitrogen_balance_core_model.R
+++ b/R/nitrogen_balance_core_model.R
@@ -58,8 +58,8 @@ compute_nitrogen_retention <- function(
 
   if (animal %in% c("CTL", "BFL", "SHP", "GTS", "CML")) {
     tissue_n <- ifelse(animal %in% c("CTL", "BFL"), 0.0326, 0.026)
-    milk_n <- milk_protein / 6.38
-    fibre_n <- 0.0134
+    milk_n <- milk_protein / 6.25
+    fibre_n <- 0.134
 
     milk_comp <- if (!is.na(milk_yield) && cohort == "FA" && milk_yield > 0) milk_yield * milk_n else 0
     growth_comp <- if (!is.na(dwg) && dwg > 0) dwg * tissue_n else 0

--- a/R/run_directemissions_manure.R
+++ b/R/run_directemissions_manure.R
@@ -106,12 +106,10 @@ run_directemissions_manure <- function(gleam_data, ipcc_method = "2019") {
   gleam_data[, paste0("vs", ipcc_method) :=
                calc_volatile_solids(
                  animal = Animal_short,
-                 lps_short = LPS_short,
                  dmi = dmi,
                  diet_dig = diet_dig,
                  diet_me = diet_me,
-                 diet_ge = diet_ge,
-                 ipcc_method = ipcc_method
+                 diet_ge = diet_ge
                ),
              by = .I
   ]

--- a/R/validate_directemissions_manure_core_model.R
+++ b/R/validate_directemissions_manure_core_model.R
@@ -1,13 +1,10 @@
 #' Validate inputs for calc_volatile_solids
 #'
 #' @noRd
-validate_manure_inputs <- function(animal_short, lps_short, dmi, diet_dig, diet_me, diet_ge, ipcc_method) {
+validate_manure_inputs <- function(animal_short, dmi, diet_dig, diet_me, diet_ge) {
   # Character inputs
   if (!is.character(animal_short) || length(animal_short) == 0 || anyNA(animal_short)) {
     cli::cli_abort("{.arg animal_short} must be a non-empty character vector.")
-  }
-  if (!is.character(lps_short) || length(lps_short) == 0 || anyNA(lps_short)) {
-    cli::cli_abort("{.arg lps_short} must be a non-empty character vector.")
   }
 
   # Validate animal species
@@ -16,12 +13,6 @@ validate_manure_inputs <- function(animal_short, lps_short, dmi, diet_dig, diet_
     cli::cli_abort(
       "{.arg animal_short} must contain only values from: {cli::format_inline('{valid_animals}')}"
     )
-  }
-
-  # Validate ipcc_method
-  valid_methods <- c("2006", "2019")
-  if (!is.character(ipcc_method) || length(ipcc_method) != 1 || !ipcc_method %in% valid_methods) {
-    cli::cli_abort("{.arg ipcc_method} must be one of: {cli::format_inline('{valid_methods}')}")
   }
 
   # Numeric inputs

--- a/man/calc_ch4_emissions.Rd
+++ b/man/calc_ch4_emissions.Rd
@@ -15,30 +15,44 @@ calc_ch4_emissions(
 )
 }
 \arguments{
-\item{vs}{Numeric vector of volatile solids (kg VS/head/day)}
+\item{vs}{Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).}
 
-\item{mcf_pasture}{Numeric vector of methane conversion factor for pasture (dimensionless)}
+\item{mcf_pasture}{Numeric. Effective methane conversion factor for manure deposited on pasture (mcfpasture), expressed in percent (\%), and already weighted by the share of manure deposited on pasture (mmspasture) (percentage)}
 
-\item{mcf_burned}{Numeric vector of methane conversion factor for burned (dimensionless)}
+\item{mcf_burned}{Numeric. Effective methane conversion factor for manure burned for fuel (mcfburned), expressed in percent (\%), and already weighted by the share of manure burned for fuel (mmsburned) (percentage)}
 
-\item{mcf_other}{Numeric vector of methane conversion factor for other systems (dimensionless)}
+\item{mcf_other}{Numeric. Effective methane conversion factor for manure managed in non-pasture, non-burned manure management systems, expressed in percent (\%), and already weighted by the share of each corresponding manure management system (e.g., mmsolid, mmsliquid...etc.) (percentage)}
 
-\item{b0_mms_all}{Numeric vector of maximum methane producing capacity for all systems (m³ CH4/kg VS)}
+\item{b0_mms_all}{Numeric. Maximum methane producing capacity for all systems (m³ CH4/kg VS). The value should is region- and species-specific. Default can be selected from Table 10.16 (IPCC, 2019) or from Tables 10A-4 to 10A-9 (IPCC, 2006)}
 
-\item{b0_mms_pasture}{Numeric vector of maximum methane producing capacity for pasture (m³ CH4/kg VS)}
+\item{b0_mms_pasture}{Numeric. Maximum methane producing capacity for manure deposited on pasture (m³ CH4/kg VS). Default can be selected from Table 10.16 (IPCC, 2019). For IPCC 2006 method, it is assumed to be equal to b0_mms_all.}
 
-\item{ratio_m3CH4_kgCH4}{Numeric. Conversion factor from m³ CH4 to kg CH4. Defaults to 0.67.}
+\item{ratio_m3CH4_kgCH4}{Numeric. Conversion factor from m³ CH4 to kg CH4. Default to 0.67.}
 }
 \value{
 A named list with:
 \describe{
-\item{ch4_manure_pasture}{CH4 emissions from pasture (kg CH4/head/day)}
-\item{ch4_manure_burned}{CH4 emissions from burned manure (kg CH4/head/day)}
-\item{ch4_manure_other}{CH4 emissions from other systems (kg CH4/head/day)}
-\item{ch4_manure_all_noburn}{Total CH4 emissions excluding burned (kg CH4/head/day)}
+\item{ch4_manure_pasture}{Numeric. Methane emissions from manure deposited on pasture (kg CH4/head/day))}
+\item{ch4_manure_burned}{Numeric. Methane emissions from manure burned for fuel (kg CH4/head/day)}
+\item{ch4_manure_other}{Numeric. Methane emissions from manure managed in all other manure management systems, excluding emissions from manure deposired on pasture and burned (kg CH4/head/day)}
+\item{ch4_manure_all_noburn}{Numeric. Methane emissions from manure managed in all other manure management systems and deposited on pasture, excluding emissions from burned manure (kg CH4/head/day)}
 }
 }
 \description{
-Calculates methane emissions from manure management systems using volatile solids,
-methane conversion factors, and maximum methane producing capacity (B0).
+Calculates \strong{methane (CH4) emissions} attributable to manure management pathways using
+the IPCC Tier 2 framework. The computation follows the structure of IPCC
+Eq. 10.23 (CH\eqn{_4} emission factor from manure management), but expressed on
+a daily basis because \code{vs} is provided as kg VS/head/day.
+}
+\details{
+This function expects that methane conversion factors
+(\code{mcf_pasture}, \code{mcf_burned}, \code{mcf_other}) are provided as
+\strong{weighted fractions}, i.e. they have already been multiplied by the relative manure management system shares (mms)
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.23.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.23.
 }

--- a/man/calc_direct_n2o_emissions.Rd
+++ b/man/calc_direct_n2o_emissions.Rd
@@ -9,30 +9,46 @@ calc_direct_n2o_emissions(
   ef3_pasture,
   ef3_burned,
   ef3_other,
-  ratio_N2O_N2ON = 44/28
+  ration_N2ON_to_N2O = 44/28
 )
 }
 \arguments{
-\item{n_excretion}{Numeric vector of nitrogen excretion (kg N/head/day)}
+\item{n_excretion}{Numeric. Daily nitrogen excretion (kg N/head/day)}
 
-\item{ef3_pasture}{Numeric vector of EF3 emission factor for pasture (kg N2O-N/kg N)}
+\item{ef3_pasture}{Numeric. Effective EF3 factor for manure deposited on pasture (ef3pasture), expressed in kg N2O-N / kg N excreted, and already weighted by the share of manure deposited on pasture (mmspasture) (kg N2O-N / kg N excreted)}
 
-\item{ef3_burned}{Numeric vector of EF3 emission factor for burned (kg N2O-N/kg N)}
+\item{ef3_burned}{Numeric. Effective EF3 factor for manure burned for fuel (ef3burned), expressed in kg N2O-N / kg N excreted, and already weighted by the share of manure burned for fuel (mmsburned) (kg N2O-N / kg N excreted)}
 
-\item{ef3_other}{Numeric vector of EF3 emission factor for other systems (kg N2O-N/kg N)}
+\item{ef3_other}{Numeric. Effective EF3 factor for manure managed in non-pasture, non-burned manure management systems, expressed in g N2O-N / kg N excreted, and already weighted by the share of each corresponding manure management system (e.g., mmsolid, mmsliquid...etc.) (kg N2O-N / kg N excreted)}
 
-\item{ratio_N2O_N2ON}{Numeric. Conversion factor from kg N2O-N to kg N2O. Defaults to 44/28.}
+\item{ration_N2ON_to_N2O}{Numeric. Conversion factor from kg N2O-N to kg N2O. Default to 44/28.}
 }
 \value{
 A named list with:
 \describe{
-\item{direct_n2o_manure_pasture}{Direct N2O emissions from pasture (kg N2O/head/day)}
-\item{direct_n2o_manure_burned}{Direct N2O emissions from burned manure (kg N2O/head/day)}
-\item{direct_n2o_manure_other}{Direct N2O emissions from other systems (kg N2O/head/day)}
-\item{direct_n2o_manure_all_noburn}{Total direct N2O emissions excluding burned (kg N2O/head/day)}
+\item{direct_n2o_manure_pasture}{Numeric. Direct nitrous oxide emissions from manure deposited on pasture (kg N2O/head/day)}
+\item{direct_n2o_manure_burned}{Numeric. Direct nitrous oxide emissions from manure burned for fuel (kg N2O/head/day)}
+\item{direct_n2o_manure_other}{Numeric. Direct nitrous oxide emissions from manure managed in all other manure management systems, excluding emissions from manure deposired on pasture and burned (kg N2O/head/day)}
+\item{direct_n2o_manure_all_noburn}{Numeric. Direct nitrous oxide emissions from manure managed in all other manure management systems and deposited on pasture, excluding emissions from burned manure (kg N2O/head/day)}
 }
 }
 \description{
-Calculates direct nitrous oxide emissions from manure management systems
-using nitrogen excretion and EF3 emission factors.
+Calculates \strong{direct nitrous oxide (N2O)} emissions from manure management
+pathways using the IPCC Tier 2 framework. The calculation follows the structure of
+IPCC Eq. 10.25 (direct N2O emissions from manure management), but is expressed
+on a \strong{daily basis} because \code{n_excretion} is provided in
+kg N/head/day.
+}
+\details{
+This function expects that the emission-factor inputs
+(\code{ef3_pasture}, \code{ef3_burned}, \code{ef3_other}) are provided as
+\strong{effective (already weighted) factors}, i.e. they have already been
+multiplied by the corresponding manure management system shares (mms).
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.25.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.25.
 }

--- a/man/calc_n2o_from_leaching.Rd
+++ b/man/calc_n2o_from_leaching.Rd
@@ -9,29 +9,43 @@ calc_n2o_from_leaching(
   n_leach_burned,
   n_leach_other,
   ef5,
-  ratio_N2O_N2ON = 44/28
+  ration_N2ON_to_N2O = 44/28
 )
 }
 \arguments{
-\item{n_leach_pasture}{Numeric vector of nitrogen leached from pasture (kg N/head/day)}
+\item{n_leach_pasture}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure deposited on pasture (kg N/head/day).}
 
-\item{n_leach_burned}{Numeric vector of nitrogen leached from burned manure (kg N/head/day)}
+\item{n_leach_burned}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure burned for fuel (kg N/head/day).}
 
-\item{n_leach_other}{Numeric vector of nitrogen leached from other systems (kg N/head/day)}
+\item{n_leach_other}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure managed in all other systems, excluding losses from manure deposited on pasture and manure burned for fuel (kg N/head/day).}
 
-\item{ef5}{Numeric vector of EF5 emission factor (kg N2O-N/kg N)}
+\item{ef5}{Numeric. Emission factor for indirect nitrous oxide emissions resulting from nitrogen leaching and runoff, expressed as kilograms of N₂O–N per kilogram of nitrogen leached or lost through runoff (kg N₂O–N / kg N leached and runoff).}
 
-\item{ratio_N2O_N2ON}{Numeric. Conversion factor from kg N2O-N to kg N2O. Defaults to 44/28.}
+\item{ration_N2ON_to_N2O}{Numeric. Conversion factor from kg N2O-N to kg N2O. Default to 44/28.}
 }
 \value{
 A named list with:
 \describe{
-\item{n2o_leach_manure_pasture}{N2O emissions from leached nitrogen from pasture (kg N2O/head/day)}
-\item{n2o_leach_manure_burned}{N2O emissions from leached nitrogen from burned manure (kg N2O/head/day)}
-\item{n2o_leach_manure_other}{N2O emissions from leached nitrogen from other systems (kg N2O/head/day)}
-\item{n2o_leach_manure_all_noburn}{Total N2O emissions from leaching excluding burned (kg N2O/head/day)}
+\item{n2o_leach_manure_pasture}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from manure deposited on pasture (kg N₂O/head/day).}
+\item{n2o_leach_manure_burned}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from manure burned for fuel (kg N₂O/head/day).}
+\item{n2o_leach_manure_other}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from manure managed in all other systems, excluding manure deposited on pasture and manure burned for fuel (kg N₂O/head/day).}
+\item{n2o_leach_manure_all_noburn}{Numeric. Indirect nitrous oxide emissions resulting from leaching and runoff of manure nitrogen originating from all non-burned manure management systems, including manure deposited on pasture (kg N₂O/head/day).}
 }
+
+#' @references
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.29.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.29.
 }
 \description{
-Calculates nitrous oxide emissions from leached nitrogen using EF5 emission factors.
+Converts leached/runoff manure nitrogen losses (kg N/head/day) into indirect
+nitrous oxide (N\eqn{_2}O) emissions using the emission factor \code{ef5}
+(kg N2O-N per kg N leached/runoff), consistent with the IPCC framework
+for indirect N2O from leaching/runoff.
+}
+\details{
+The calculation is implemented on a \strong{daily basis} because volatilized nitrogen
+inputs are provided as kg N/head/day.
 }

--- a/man/calc_n2o_from_volatilization.Rd
+++ b/man/calc_n2o_from_volatilization.Rd
@@ -9,29 +9,41 @@ calc_n2o_from_volatilization(
   n_vol_burned,
   n_vol_other,
   ef4,
-  ratio_N2O_N2ON = 44/28
+  ration_N2ON_to_N2O = 44/28
 )
 }
 \arguments{
-\item{n_vol_pasture}{Numeric vector of nitrogen volatilized from pasture (kg N/head/day)}
+\item{n_vol_pasture}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure deposited on pasture (kg N/head/day).}
 
-\item{n_vol_burned}{Numeric vector of nitrogen volatilized from burned manure (kg N/head/day)}
+\item{n_vol_burned}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure burned for fuel (kg N/head/day).}
 
-\item{n_vol_other}{Numeric vector of nitrogen volatilized from other systems (kg N/head/day)}
+\item{n_vol_other}{"Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure managed in all other systems, excluding losses from manure deposited on pasture and burned for fuel (kg N/head/day).}
 
-\item{ef4}{Numeric vector of EF4 emission factor (kg N2O-N/kg N)}
+\item{ef4}{Numeric. Emission factor for indirect nitrous oxide (N₂O) emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃–N and NOₓ–N) onto soils and water surfaces (kg N₂O–N / (kg NH₃–N + NOₓ–N)).}
 
-\item{ratio_N2O_N2ON}{Numeric. Conversion factor from kg N2O-N to kg N2O. Defaults to 44/28.}
+\item{ration_N2ON_to_N2O}{Numeric. Conversion factor from kg N2O-N to kg N2O. Default to 44/28}
 }
 \value{
 A named list with:
 \describe{
-\item{n2o_vol_manure_pasture}{N2O emissions from volatilized nitrogen from pasture (kg N2O/head/day)}
-\item{n2o_vol_manure_burned}{N2O emissions from volatilized nitrogen from burned manure (kg N2O/head/day)}
-\item{n2o_vol_manure_other}{N2O emissions from volatilized nitrogen from other systems (kg N2O/head/day)}
-\item{n2o_vol_manure_all_noburn}{Total N2O emissions from volatilization excluding burned (kg N2O/head/day)}
+\item{n2o_vol_manure_pasture}{Numeric. Indirect nitrous oxide emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure deposited on pasture (kg N2O/head/day)}
+\item{n2o_vol_manure_burned}{Numeric. Indirect nitrous oxide emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure burned for fuel (kg N2O/head/day)}
+\item{n2o_vol_manure_other}{Numeric. Indirect nitrous oxide (N₂O) emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure managed in all other manure management systems, excluding manure deposited on pasture and manure burned for fuel (kg N2O/head/day)}
+\item{n2o_vol_manure_all_noburn}{Numeric. Indirect nitrous oxide (N₂O) emissions resulting from atmospheric deposition of volatilized nitrogen (NH₃ and NOₓ) originating from manure managed in all non-burned manure management systems, including manure deposited on pasture (kg N2O/head/day)}
 }
 }
 \description{
-Calculates nitrous oxide emissions from volatilized nitrogen using EF4 emission factors.
+Converts volatilized manure nitrogen (NH\eqn{_3} and NO\eqn{_x}) into indirect
+nitrous oxide (N\eqn{_2}O) emissions using the IPCC emission factor \code{EF4}.
+}
+\details{
+The calculation is implemented on a \strong{daily basis} because volatilized nitrogen
+inputs are provided as kg N/head/day.
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.28.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.28.
 }

--- a/man/calc_nitrogen_leaching.Rd
+++ b/man/calc_nitrogen_leaching.Rd
@@ -12,24 +12,39 @@ calc_nitrogen_leaching(
 )
 }
 \arguments{
-\item{n_excretion}{Numeric vector of nitrogen excretion (kg N/head/day)}
+\item{n_excretion}{Numeric. Daily nitrogen excretion (kg N/head/day)}
 
-\item{fracleach_pasture}{Numeric vector of leaching fraction for pasture (0-1)}
+\item{fracleach_pasture}{Numeric. Effective fraction of excreted nitrogen lost through leaching and runoff from manure deposited on pasture, already weighted by the share of manure deposited on pasture (mmspasture) (fraction).}
 
-\item{fracleach_burned}{Numeric vector of leaching fraction for burned (0-1)}
+\item{fracleach_burned}{Numeric. Effective fraction of excreted nitrogen lost through leaching and runoff from manure burned for fuel, already weighted by the share of manure burned (mmsburned) (fraction).}
 
-\item{fracleach_other}{Numeric vector of leaching fraction for other systems (0-1)}
+\item{fracleach_other}{Numeric. Effective fraction of excreted nitrogen lost through leaching and runoff from manure managed in non-pasture, non-burned manure management systems, already weighted by the shares of the corresponding manure management systems (e.g. solid storage, drylot, liquid/slurry) (fraction).}
 }
 \value{
 A named list with:
 \describe{
-\item{n_leach_manure_pasture}{Nitrogen leached from pasture (kg N/head/day)}
-\item{n_leach_manure_burned}{Nitrogen leached from burned manure (kg N/head/day)}
-\item{n_leach_manure_other}{Nitrogen leached from other systems (kg N/head/day)}
-\item{n_leach_manure_all_noburn}{Total nitrogen leached excluding burned (kg N/head/day)}
+\item{n_leach_manure_pasture}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure deposited on pasture (kg N/head/day).}
+\item{n_leach_manure_burned}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure burned for fuel (kg N/head/day).}
+\item{n_leach_manure_other}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure managed in all other systems, excluding losses from manure deposited on pasture and manure burned for fuel (kg N/head/day).}
+\item{n_leach_manure_all_noburn}{Numeric. Amount of manure nitrogen lost through leaching and runoff from manure managed in all other systems and deposited on pasture, excluding losses from manure burned for fuel (kg N/head/day).}
 }
 }
 \description{
-Calculates nitrogen lost via leaching from manure management systems
-using nitrogen excretion and leaching fractions.
+Calculates the amount of manure nitrogen lost via \strong{leaching and runoff}
+from manure management systems (kg N/head/day). This follows the IPCC
+structure of Eq. 10.27, but expressed on a \strong{daily} basis because
+\code{n_excretion} is provided in kg N/head/day.
+}
+\details{
+The function assumes leaching/runoff fractions - (\code{fracleach_pasture}, \code{fracleach_burned}, \code{fracleach_other}) -
+are provided as \strong{effective
+weighted fractions}, i.e. they have already been multiplied by the
+corresponding manure management system shares (mms fractions).
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.27.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.27.
 }

--- a/man/calc_nitrogen_volatilization.Rd
+++ b/man/calc_nitrogen_volatilization.Rd
@@ -12,24 +12,39 @@ calc_nitrogen_volatilization(
 )
 }
 \arguments{
-\item{n_excretion}{Numeric vector of nitrogen excretion (kg N/head/day)}
+\item{n_excretion}{Numeric. Daily nitrogen excretion (kg N/head/day)}
 
-\item{fracgas_pasture}{Numeric vector of volatilization fraction for pasture (0-1)}
+\item{fracgas_pasture}{Numeric. Effective fraction of excreted nitrogen volatilized as NH₃ and NOₓ from manure deposited on pasture, already weighted by the share of manure deposited on pasture (mmspasture) (fraction).}
 
-\item{fracgas_burned}{Numeric vector of volatilization fraction for burned (0-1)}
+\item{fracgas_burned}{Numeric. Effective fraction of excreted nitrogen volatilized as NH₃ and NOₓ from manure burned for fuel, already weighted by the share of manure burned (mmsburned) (fraction).}
 
-\item{fracgas_other}{Numeric vector of volatilization fraction for other systems (0-1)}
+\item{fracgas_other}{Numeric. Effective fraction of excreted nitrogen volatilized as NH₃ and NOₓ from manure managed in non-pasture, non-burned manure management systems, already weighted by the shares of the corresponding systems (fraction).}
 }
 \value{
 A named list with:
 \describe{
-\item{n_vol_manure_pasture}{Nitrogen volatilized from pasture (kg N/head/day)}
-\item{n_vol_manure_burned}{Nitrogen volatilized from burned manure (kg N/head/day)}
-\item{n_vol_manure_other}{Nitrogen volatilized from other systems (kg N/head/day)}
-\item{n_vol_manure_all_noburn}{Total nitrogen volatilized excluding burned (kg N/head/day)}
+\item{n_vol_manure_pasture}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure deposited on pasture (kg N/head/day)}
+\item{n_vol_manure_burned}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure burned for fuel (kg N/head/day)}
+\item{n_vol_manure_other}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure managed in all other systems, excluding losses from manure deposited on pasture and burned for fuel (kg N/head/day)}
+\item{n_vol_manure_all_noburn}{Numeric. Amount of manure nitrogen lost through volatilisation of NH₃ and NOₓ from manure managed in all other systems and deposited on pasture, excluding losses from manure burned for fuel (kg N/head/day)}
 }
 }
 \description{
-Calculates nitrogen lost via volatilization from manure management systems
-using nitrogen excretion and volatilization fractions.
+Computes nitrogen lost through volatilization as NH3 and NOx from manure
+management pathways. The calculation follows the IPCC structure
+(Eq. 10.26), but is expressed on a \strong{daily} basis because \code{n_excretion}
+is provided in kg N/head/day.
+}
+\details{
+This function expects volatilization fractions
+(\code{fracgas_pasture}, \code{fracgas_burned}, \code{fracgas_other}) to be provided as
+\strong{effective (already weighted)} fractions, i.e. each fraction has already
+been multiplied by the corresponding manure management system share (mms).
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.26.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.26.
 }

--- a/man/calc_total_n2o_emissions.Rd
+++ b/man/calc_total_n2o_emissions.Rd
@@ -19,14 +19,15 @@ n2o_leach_manure_pasture, n2o_leach_manure_burned, n2o_leach_manure_other}
 \value{
 A named list with:
 \describe{
-\item{indirect_n2o_manure_pasture}{Indirect N2O emissions from pasture (kg N2O/head/day)}
-\item{indirect_n2o_manure_burned}{Indirect N2O emissions from burned manure (kg N2O/head/day)}
-\item{indirect_n2o_manure_other}{Indirect N2O emissions from other systems (kg N2O/head/day)}
-\item{total_n2o_manure_pasture}{Total N2O emissions from pasture (kg N2O/head/day)}
-\item{total_n2o_manure_burned}{Total N2O emissions from burned manure (kg N2O/head/day)}
-\item{total_n2o_manure_other}{Total N2O emissions from other systems (kg N2O/head/day)}
+\item{indirect_n2o_manure_pasture}{Numeric. Total indirect nitrous oxide (emissions originating from manure deposited on pasture, including emissions from atmospheric deposition of volatilised nitrogen (NH₃ and NOₓ) and from leaching and runoff of manure nitrogen (kg N₂O/head/day).}
+\item{indirect_n2o_manure_burned}{Numeric. Total indirect nitrous oxide emissions originating from manure burned for fuel, including emissions from atmospheric deposition of volatilised nitrogen (NH₃ and NOₓ) and from leaching and runoff of manure nitrogen (kg N₂O/head/day).}
+\item{indirect_n2o_manure_other}{Numeric. Total indirect nitrous oxide emissions originating from manure managed in all other manure management systems, excluding manure deposited on pasture and manure burned for fuel, including emissions from atmospheric deposition of volatilised nitrogen (NH₃ and NOₓ) and from leaching and runoff of manure nitrogen}
+\item{total_n2o_manure_pasture}{Numeric. Total nitrous oxide emissions from manure deposited on pasture, including direct emissions and indirect emissions from volatilisation, leaching, and runoff (kg N₂O/head/day).}
+\item{total_n2o_manure_burned}{Numeric. Total nitrous oxide emissions from manure burned for fuel, including direct emissions and indirect emissions from volatilisation, leaching, and runoff (kg N₂O/head/day).}
+\item{total_n2o_manure_other}{Numeric. Total nitrous oxide emissions from manure managed in all other manure management systems, excluding manure deposited on pasture and manure burned for fuel, including direct emissions and indirect emissions from volatilisation, leaching, and runoff (kg N₂O/head/day).}
 }
 }
 \description{
-Calculates total nitrous oxide emissions (direct + indirect) from manure management systems.
+The function aggregates \strong{direct} and \strong{indirect} nitrous oxide emissions attributable to
+manure management, expressed on a \strong{head/day} basis.
 }

--- a/man/calc_volatile_solids.Rd
+++ b/man/calc_volatile_solids.Rd
@@ -4,35 +4,67 @@
 \alias{calc_volatile_solids}
 \title{Calculate Volatile Solids for Manure Emissions}
 \usage{
-calc_volatile_solids(
-  animal,
-  lps_short,
-  dmi,
-  diet_dig,
-  diet_me,
-  diet_ge,
-  ipcc_method
-)
+calc_volatile_solids(animal, dmi, diet_dig, diet_me, diet_ge)
 }
 \arguments{
-\item{animal}{Character. Animal type (CTL, BFL, CML, SHP, GTS, PGS, CHK)}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{lps_short}{Character. Livestock production system}
+\item{dmi}{Numeric. Daily dry matter intake of feed (kg DM/head/day).}
 
-\item{dmi}{Numeric. Dry matter intake (kg/head/day)}
+\item{diet_dig}{Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)}
 
-\item{diet_dig}{Numeric. Diet digestibility (0-1)}
+\item{diet_me}{Numeric. Average metabolizable energy content of the diet (MJ/kg DM).}
 
-\item{diet_me}{Numeric. Metabolizable energy content (MJ/kg DM)}
-
-\item{diet_ge}{Numeric. Gross energy content (MJ/kg DM)}
-
-\item{ipcc_method}{Character. IPCC method ('2006' or '2019')}
+\item{diet_ge}{Numeric. Average gross energy content of the diet (MJ/kg DM).}
 }
 \value{
-Numeric. Volatile solids (kg VS/head/day)
+Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).
 }
 \description{
-Calculates volatile solids (VS) production from animal feed intake and diet composition
-using IPCC methodology for different animal types and production systems.
+Computes daily volatile solids (VS) excretion in manure (kg VS/head/day).
+VS represents the total organic material excreted (biodegradable + non-biodegradable)
+and is required to proceed with the estimate of methane emissions from manure maanagement.
+}
+\details{
+The IPCC recommends estimating VS from feed intake and digestibility when
+country-specific average daily VS excretion rates are not available. The core relationship is
+given in \strong{IPCC Equation 10.24 (Volatile solids excretion rates)}, which uses gross energy (GE)
+intake, digestibility (DE), urinary energy as a fraction of GE (UE·GE), ash fraction (ASH), and
+a conversion factor of 18.45 MJ/kg DM.
+
+\strong{Implementation note (simplified coefficients).}
+This package uses simplified algebraic forms by species/method that are consistent with the
+structure of Eq. 10.24 under fixed/default assumptions for \eqn{UE} and \eqn{ASH}, and with
+digestibility supplied directly as a fraction (\code{diet_dig}).
+
+\strong{Species/method branches}
+\itemize{
+\item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
+\code{vs = dmi * (1.04 - diet_dig) * 0.92}.
+The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
+of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi.
+Second, it is assumed that Urinary energy is 4\% and the Ash content in feed is 8\%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
+}
+\item \strong{Swine} (\code{"PGS"}):
+\itemize{
+\item \code{vs = dmi * (1.02 - diet_dig) * 0.94}.
+It is assumed that urinary energy is 2\% and the ash content in feed is 6\% (based on IPCC, 2019). Therefore, GE × (GE + UE) becomes 1.02 and 1 – ASH becomes 0.94.
+}
+}
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.24.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.24.
 }

--- a/man/compute_nitrogen_excretion.Rd
+++ b/man/compute_nitrogen_excretion.Rd
@@ -7,16 +7,35 @@
 compute_nitrogen_excretion(animal, n_intake, n_retention)
 }
 \arguments{
-\item{animal}{Character. Species code (e.g., "PGS", "CML", "CTL", "BFL", "SHP", "GTS").}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{n_intake}{Numeric. Nitrogen intake (kg N/head/day).}
+\item{n_intake}{Numeric. Daily nitrogen intake (kg N/head/day)}
 
-\item{n_retention}{Numeric. Nitrogen retention (kg N/head/day).}
+\item{n_retention}{Numeric.  Daily nitrogen retention in animal body tissues and products (e.g., growth, pregnancy, milk...) (kg N/head/day)}
 }
 \value{
 Numeric. Daily nitrogen excretion (kg N/head/day).
 }
 \description{
-Calculates nitrogen excretion (kg N/head/day) as the difference between
-nitrogen intake and retention for applicable species.
+Calculates daily nitrogen excretion per animal (kg N/head/day) as the difference between
+nitrogen intake and nitrogen retention.
+}
+\details{
+Nitrogen excretion represents the fraction of consumed nitrogen that is not
+retained in animal products or body tissues and is therefore excreted in urine
+and dung. This quantity forms the basis for subsequent calculations of
+nitrous oxide (N2O) emissions from manure management and agricultural soils.
+The approach follows the Tier 2 IPCC guidelines.
+}
+\references{
+Livestock and Manure Management. Equation 10.31A.
 }

--- a/man/compute_nitrogen_excretion.Rd
+++ b/man/compute_nitrogen_excretion.Rd
@@ -37,5 +37,6 @@ nitrous oxide (N2O) emissions from manure management and agricultural soils.
 The approach follows the Tier 2 IPCC guidelines.
 }
 \references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
 Livestock and Manure Management. Equation 10.31A.
 }

--- a/man/compute_nitrogen_intake.Rd
+++ b/man/compute_nitrogen_intake.Rd
@@ -7,14 +7,21 @@
 compute_nitrogen_intake(dmi, diet_nitrogen)
 }
 \arguments{
-\item{dmi}{Numeric. Dry matter intake of feed (kg DM/head/day).}
+\item{dmi}{Numeric. Daily dry matter intake of feed (kg DM/head/day).}
 
-\item{diet_nitrogen}{Numeric. Nitrogen content per kg of feed dry matter intake (kg N/kg DM).}
+\item{diet_nitrogen}{Numeric. Average nitrogen content of diet (kg N/kg DM).}
 }
 \value{
-Numeric. Daily nitrogen intake (kg N/head/day).
+Numeric. Daily nitrogen intake (kg N/head/day)
 }
 \description{
-Calculates nitrogen intake as the product of dry matter intake (DMI) and diet nitrogen content.
-This represents the gross nitrogen consumed per head per day.
+Calculates the daily nitrogen intake per head as the product of dry matter intake (DMI) and diet nitrogen content.
+The approach follows the Tier 2 IPCC guidelines (IPCC 2006, 2019).
+}
+\references{
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.32.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.32.
 }

--- a/man/compute_nitrogen_retention.Rd
+++ b/man/compute_nitrogen_retention.Rd
@@ -19,33 +19,119 @@ compute_nitrogen_retention(
 )
 }
 \arguments{
-\item{animal}{Character. Species code (e.g., "PGS", "CML", "CTL", "BFL", "SHP", "GTS").}
+\item{animal}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+}}
 
-\item{cohort}{Character. Cohort code (e.g., "FJ", "MJ", "FS", "MS", "FA", "MA").}
+\item{cohort}{"Character. Sex- and age-specific cohort code describing the
+production stage of the animals. Supported values include:
+\itemize{
+\item \code{FA}: adult females (from age at first parturition)
+\item \code{FS}: sub-adult females (from weaning to age at first parturition)
+\item \code{FJ}: juvenile females (from birth to weaning)
+\item \code{MA}: adult males (from age at first breeding)
+\item \code{MS}: sub-adult males (from weaning to age at first breeding)
+\item \code{MJ}: juvenile males (from birth to weaning)
+}}
 
-\item{milk_protein}{Numeric. Milk protein content (fraction), used to derive milk nitrogen.}
+\item{milk_protein}{Numeric. Milk protein fraction (kg protein / kg milk).}
 
-\item{milk_yield}{Numeric. Milk yield (kg/head/day).}
+\item{milk_yield}{Numeric. Average milk yield per milk-producing animal during the assessment duration (kg/head/day). This value can be calculated by dividing the total milk destinated to human consumption produced per milk-producing animal over the assessment duration by the length of the assessment period.}
 
-\item{dwg}{Numeric. Daily weight gain (kg/head/day).}
+\item{dwg}{Numeric. Average live weight of the cohort over the cohort stage (kg/head/day).}
 
-\item{fibre_prod}{Numeric. Production yield of fibre, such as wool, cashmere, mohair (kg/head/year).}
+\item{fibre_prod}{Numeric. Annual production yield of fibre, such as wool, cashmere, mohair (kg/head/year).}
 
-\item{litsize}{Numeric. Litter size (mean number of offspring per parturition).}
+\item{litsize}{Numeric. Average number of offspring born per parturition (#). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.}
 
-\item{parturition_rate}{Numeric. Annual parturition rate of adult females (parturitions/head/year).}
+\item{parturition_rate}{Numeric. Numeric. Average annual number of parturitions per female animal (fraction). At herd level, calculated as offspring delivered divided by the number of adult females.}
 
-\item{wkg}{Numeric. Weaning weight (kg).}
+\item{wkg}{Numeric. Live weight of the animal at weaning (kg)}
 
-\item{ckg}{Numeric. Birth weight (kg).}
+\item{ckg}{Numeric. Live weight of the animal at birth (kg).}
 
-\item{afc}{Numeric. Age at first parturition (years).}
+\item{afc}{Numeric. Age at first parturition for female breeding animals (years)}
 }
 \value{
-Numeric. Daily nitrogen retention (kg N/head/day).
+Numeric.  Daily nitrogen retention in animal body tissues and products (e.g., growth, pregnancy, milk...) (kg N/head/day)
 }
 \description{
-Calculates nitrogen retention by species and cohort. Retention includes nitrogen
-retained in milk, growth, and fibre (for ruminants only), and in growth and reproductive processes (for pigs only).
-Chickens are not implemented yet and return \code{NA}.
+Calculates daily nitrogen retention per animal by species and cohort.
+Nitrogen retention represents the portion of consumed nitrogen that is
+incorporated into animal products or body tissues.
+The approach follows the Tier 2 IPCC guidelines (IPCC 2006, 2019).
+}
+\details{
+Species-specific calculations are performed.
+\subsection{Ruminants and camelids (CTL, BFL, SHP, GTS, CML)}{
+
+For ruminants and camelids, nitrogen retained in products and tissues is
+computed consistent with the process described in the Technical paper
+from MPI (Ministry for Primary Industries (MPI), 2025).
+
+Nitrogen retention is calculated as the sum of:
+\itemize{
+\item nitrogen secreted in milk,
+\item nitrogen retained in liveweight gain (tissue),
+\item nitrogen retained in fibre (for fibre-producing species).
+}
+
+Coefficients for nitrogen content of deposited tissue, fibre, and milk are
+derived from Chapter 5 (Nitrogen excretion) of the MPI inventory methodology.
+
+The following constants are used:
+\itemize{
+\item \strong{Tissue nitrogen content (\code{tissue_n})}:
+\itemize{
+\item Cattle (\code{CTL}, \code{BFL}): \strong{0.0326 kg N per kg live weight}
+\item Sheep (\code{SHP}), goats (\code{GTS}) and camelids (\code{CML}):
+\strong{0.026 kg N per kg live weight}
+}
+\item \strong{Fibre nitrogen content (\code{fibre_n})}:
+\strong{0.134 kg N per kg fibre}
+\item \strong{Milk nitrogen content}:
+Milk nitrogen is derived from milk protein using a protein-to-nitrogen
+conversion factor of \strong{6.25}
+}
+}
+
+\subsection{Pigs (PGS)}{
+
+For pigs, nitrogen retention is calculated following the IPCC 2019 equations
+for swine (Equations 10.33A and 10.33B).
+
+Nitrogen retention includes nitrogen retained in:
+\itemize{
+\item body growth,
+\item reproductive outputs (conceptus and weaned offspring).
+}
+
+Calculations are expressed on a daily basis. In this implementation:
+\itemize{
+\item \code{0.025} represents the nitrogen content of liveweight gain
+(kg N per kg gain),
+\item \code{0.98} is the protein digestibility fraction,
+\item breeding cohorts include an annual reproductive component that is
+converted to a daily rate.
+}
+}
+}
+\references{
+Ministry for Primary Industries (MPI). (2025).
+\emph{Detailed methodologies for agricultural greenhouse gas emission calculation:
+Methodology for calculation of New Zealand’s agricultural greenhouse gas emissions}
+(Version 11). MPI Technical Paper, Wellington, New Zealand. Chapter 5.
+
+IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.33A, 10.33B.
+
+IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
+Livestock and Manure Management. Equation 10.33.
 }

--- a/tests/testthat/test-directemissions_manure_core.R
+++ b/tests/testthat/test-directemissions_manure_core.R
@@ -2,94 +2,72 @@
 test_that("calc_volatile_solids produces expected results for cattle", {
   result <- calc_volatile_solids(
     animal = "CTL",
-    lps_short = "GRS",
     dmi = 5,
     diet_dig = 0.6,
     diet_me = 9,
-    diet_ge = 18,
-    ipcc_method = "2019"
+    diet_ge = 18
   )
   expect_length(result, 1)
   expect_true(result >= 0)
   expect_equal(result, 5 * (1.04 - 0.6) * 0.92)
 })
 
-test_that("calc_volatile_solids handles PGS 2019 correctly", {
+test_that("calc_volatile_solids handles PGS correctly", {
   result <- calc_volatile_solids(
     animal = "PGS",
-    lps_short = "GRS",
     dmi = 4,
     diet_dig = 0.7,
     diet_me = 12,
-    diet_ge = 20,
-    ipcc_method = "2019"
+    diet_ge = 20
   )
   expect_equal(result, 4 * (1.02 - 0.7) * 0.94)
 })
 
-test_that("calc_volatile_solids handles PGS 2006 correctly", {
-  result <- calc_volatile_solids(
-    animal = "PGS",
-    lps_short = "GRS",
-    dmi = 4,
-    diet_dig = 0.7,
-    diet_me = 12,
-    diet_ge = 20,
-    ipcc_method = "2006"
-  )
-  expect_equal(result, 4 * (1.02 - 0.7) * 0.8)
-})
 
-test_that("calc_volatile_solids handles CHK 2019 correctly", {
-  result <- calc_volatile_solids(
-    animal = "CHK",
-    lps_short = "BRL",
-    dmi = 0.1,
-    diet_dig = 0.8,
-    diet_me = 12,
-    diet_ge = 18,
-    ipcc_method = "2019"
-  )
-  expect_equal(result, 0.1 * (1 - 12/18) * 0.70)
-})
-
-test_that("calc_volatile_solids handles CHK 2006 BRL correctly", {
-  result <- calc_volatile_solids(
-    animal = "CHK",
-    lps_short = "BRL",
-    dmi = 0.1,
-    diet_dig = 0.8,
-    diet_me = 12,
-    diet_ge = 18,
-    ipcc_method = "2006"
-  )
-  expect_equal(result, 0.1 * (1 - 12/18) * 0.95)
-})
-
-test_that("calc_volatile_solids handles CHK 2006 non-BRL correctly", {
-  result <- calc_volatile_solids(
-    animal = "CHK",
-    lps_short = "GRS",
-    dmi = 0.1,
-    diet_dig = 0.8,
-    diet_me = 12,
-    diet_ge = 18,
-    ipcc_method = "2006"
-  )
-  expect_equal(result, 0.1 * (1 - 12/18) * 0.89)
-})
+# test_that("calc_volatile_solids handles CHK correctly", {
+#   result <- calc_volatile_solids(
+#     animal = "CHK",
+#     dmi = 0.1,
+#     diet_dig = 0.8,
+#     diet_me = 12,
+#     diet_ge = 18
+#   )
+#   expect_equal(result, 0.1 * (1 - 12/18) * 0.70)
+# })
+# 
+# test_that("calc_volatile_solids handles CHK BRL correctly", {
+#   result <- calc_volatile_solids(
+#     animal = "CHK",
+#     dmi = 0.1,
+#     diet_dig = 0.8,
+#     diet_me = 12,
+#     diet_ge = 18,
+#   )
+#   expect_equal(result, 0.1 * (1 - 12/18) * 0.95)
+# })
+# 
+# test_that("calc_volatile_solids handles CHK non-BRL correctly", {
+#   result <- calc_volatile_solids(
+#     animal = "CHK",
+#     dmi = 0.1,
+#     diet_dig = 0.8,
+#     diet_me = 12,
+#     diet_ge = 18,
+#   )
+#   expect_equal(result, 0.1 * (1 - 12/18) * 0.89)
+# })
 
 test_that("calc_volatile_solids handles validation errors", {
   expect_error(
-    calc_volatile_solids("INVALID", "GRS", 5, 0.6, 9, 18, "2019"),
+    calc_volatile_solids("INVALID", 5, 0.6, 9, 18),
     "animal"
   )
   expect_error(
-    calc_volatile_solids("CTL", "GRS", -5, 0.6, 9, 18, "2019"),
+    calc_volatile_solids("CTL", -5, 0.6, 9, 18),
     "dmi"
   )
   expect_error(
-    calc_volatile_solids("CTL", "GRS", 5, 2, 9, 18, "2019"),
+    calc_volatile_solids("CTL", 5, 2, 9, 18),
     "diet_dig"
   )
 })

--- a/tests/testthat/test-nitrogen_balance_core.R
+++ b/tests/testthat/test-nitrogen_balance_core.R
@@ -29,7 +29,7 @@ test_that("retention for cattle: milk + growth add up correctly", {
     dwg = 0, fibre_prod = 0,
     litsize = 1, parturition_rate = 1
   )
-  expect_equal(base - none, 20 * (32/6.38), tolerance = 1e-12)
+  expect_equal(base - none, 20 * (32/6.25), tolerance = 1e-12)
   expect_gt(base, 0)
 })
 
@@ -47,7 +47,7 @@ test_that("retention for goats includes fibre component", {
     dwg = 0, fibre_prod = 10,
     litsize = 1, parturition_rate = 1
   )
-  expect_equal(with_fibre - base, (10/365) * 0.0134, tolerance = 1e-12)
+  expect_equal(with_fibre - base, (10/365) * 0.134, tolerance = 1e-12)
 })
 
 # ---- test compute_nitrogen_retention (sheep) ----


### PR DESCRIPTION
This PR improves methodological consistency and documentation across the manure and nitrogen balance modules, and removes unused arguments. Main changes:

- calc_volatile_solids simplification: 
   - Removed CHK (chickens) as a species (temporary), Chickens are not implemented in V1 and will be reintroduced consistently in V2.
   - Removed lps_short argument- This parameter was only required for CHK-specific logic and is no longer needed.
   - Removed ipcc_method argument - The alternative formulation previously labelled as “IPCC 2006” originates from GLEAM 2. A double check of IPCC guidelines confirmed no material differences relative to IPCC 2006 for PGS; therefore, the argument was redundant and removed.

- Corrections to nitrogen conversion factors
 - Milk protein → nitrogen conversion updated -- > Conversion factor corrected from 6.38 to 6.25 to ensure consistency with MPI nitrogen coefficients used for ruminants and camelids.
 - Fibre nitrogen content corrected --> Fixed a decimal error in fibre_n, updated from 0.0134 to 0.134 (see MPI, 2025, p. 117: Detailed methodologies for agricultural greenhouse gas emission calculation).

- Documentation improvements: Expanded and harmonised documentation for all exported nitrogen balance and for the manure-emission functions that will be released with V1 (the ones that perform weighted average were left untouched)