### PR TITLE
Add offtake_number_assessment as returned variable of the herd module (summarise_offtake())

### DIFF
--- a/R/herd_simulation_core_model.R
+++ b/R/herd_simulation_core_model.R
@@ -520,8 +520,8 @@ project_population_size <- function(
 #' }
 #'
 #' @export
-summarise_offtake <- function(size, size_end, size_avg, offtake) {
-  validate_offtake_summary_inputs(size, size_end, size_avg, offtake)
+summarise_offtake <- function(size, size_end, size_avg, offtake, assessment_duration) {
+  validate_offtake_summary_inputs(size, size_end, size_avg, offtake, assessment_duration)
 
   # Aggregate offtake: collapse 10 sex-age classes into 6
   offtake_number <- c(
@@ -547,9 +547,15 @@ summarise_offtake <- function(size, size_end, size_avg, offtake) {
   offtake_sv_number <- stock_variation + offtake_number
   offtake_sv_share <- offtake_sv_number / size
   offtake_sv_share_avg <- offtake_sv_number / size_avg
+  
+  
+  # Calculate the scaled offtake number by assessment_duration
+  # If assessment_duration = 365 this variable will be equal to offtake_number
+  
+  offtake_number_assessment <- offtake_number / 365 * assessment_duration
 
   # Assign names
-  names(stock_variation) <- names(offtake_number) <-
+  names(stock_variation) <- names(offtake_number) <-names(offtake_number_assessment) <-
     names(offtake_share) <- names(offtake_share_avg) <-
     names(offtake_sv_number) <- names(offtake_sv_share) <-
     names(offtake_sv_share_avg) <- c("FJ", "FS", "FA", "MJ", "MS", "MA")
@@ -559,6 +565,7 @@ summarise_offtake <- function(size, size_end, size_avg, offtake) {
     list(
       stock_variation = stock_variation,
       offtake_number = offtake_number,
+      offtake_number_assessment = offtake_number_assessment,
       offtake_share = offtake_share,
       offtake_share_avg = offtake_share_avg,
       offtake_sv_number = offtake_sv_number,

--- a/R/run_herd_simulation.R
+++ b/R/run_herd_simulation.R
@@ -111,7 +111,9 @@
 #' herd_level_data <- data.table::fread(herd_level_path)
 #'
 #' # Run herd simulation
-#' results <- run_herd_simulation(cohort_data, herd_level_data, assessment_duration=200)
+#' results <- run_herd_simulation(
+#' cohort_data = cohort_data, herd_level_data = herd_level_data, assessment_duration = 200
+#' )
 #'
 #' # Access results
 #' print(results$cohort_results)
@@ -128,7 +130,7 @@ run_herd_simulation <- function(
     max_years = 100,
     lambda_threshold = 1e-9,
     show_indicator = TRUE,
-    assessment_duration
+    assessment_duration = 365
 ) {
 
   # --- Step 1: Validate Inputs -----------------------------------------------

--- a/R/run_herd_simulation.R
+++ b/R/run_herd_simulation.R
@@ -68,6 +68,7 @@
 #'   reached. Defaults to `1e-9`.
 #' @param show_indicator Logical. Whether to display progress indicators during simulation.
 #'   Defaults to `TRUE`.
+#'@param assessment_duration Numeric. Length of the assessment period (days).
 #'
 #' @return A named list with two elements:
 #'   \describe{
@@ -110,7 +111,7 @@
 #' herd_level_data <- data.table::fread(herd_level_path)
 #'
 #' # Run herd simulation
-#' results <- run_herd_simulation(cohort_data, herd_level_data)
+#' results <- run_herd_simulation(cohort_data, herd_level_data, assessment_duration=200)
 #'
 #' # Access results
 #' print(results$cohort_results)
@@ -126,7 +127,8 @@ run_herd_simulation <- function(
     initial_structure = c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30),
     max_years = 100,
     lambda_threshold = 1e-9,
-    show_indicator = TRUE
+    show_indicator = TRUE,
+    assessment_duration
 ) {
 
   # --- Step 1: Validate Inputs -----------------------------------------------
@@ -224,7 +226,8 @@ run_herd_simulation <- function(
       size = popsize_result$size,
       size_end = popsize_result$size_end,
       size_avg = popsize_result$size_avg,
-      offtake = popsize_result$offtake
+      offtake = popsize_result$offtake,
+      assessment_duration = assessment_duration
     )
 
     # Map simulation results back to cohort-level results
@@ -238,6 +241,7 @@ run_herd_simulation <- function(
           size_end = popsize_result$size_end[cohort_name],
           size_avg = popsize_result$size_avg[cohort_name],
           offtake_number = offtake_result$offtake_number[cohort_name],
+          offtake_number_assessment = offtake_result$offtake_number_assessment[cohort_name],
           offtake_share = offtake_result$offtake_share[cohort_name],
           offtake_share_avg = offtake_result$offtake_share_avg[cohort_name],
           prob_death = transition_result$prob_death[cohort_name],

--- a/R/validate_herd_simulation_core_model.R
+++ b/R/validate_herd_simulation_core_model.R
@@ -180,12 +180,14 @@ validate_offtake_summary_inputs <- function(
     size,
     size_end,
     size_avg,
-    offtake
+    offtake,
+    assessment_duration
 ) {
   validate_named_numeric_vector(size, "size", 6)
   validate_named_numeric_vector(size_end, "size_end", 6)
   validate_named_numeric_vector(size_avg, "size_avg", 6)
   validate_named_numeric_vector(offtake, "offtake", 10)
+  validate_scalar_numeric(assessment_duration, "assessment_duration")
 }
 
 #' Validate inputs for calc_cohort_weights

--- a/man/run_herd_simulation.Rd
+++ b/man/run_herd_simulation.Rd
@@ -11,7 +11,7 @@ run_herd_simulation(
   max_years = 100,
   lambda_threshold = 1e-09,
   show_indicator = TRUE,
-  assessment_duration
+  assessment_duration = 365
 )
 }
 \arguments{
@@ -140,7 +140,9 @@ cohort_data <- data.table::fread(cohort_path)
 herd_level_data <- data.table::fread(herd_level_path)
 
 # Run herd simulation
-results <- run_herd_simulation(cohort_data, herd_level_data, assessment_duration=200)
+results <- run_herd_simulation(
+cohort_data = cohort_data, herd_level_data = herd_level_data, assessment_duration = 200
+)
 
 # Access results
 print(results$cohort_results)

--- a/man/run_herd_simulation.Rd
+++ b/man/run_herd_simulation.Rd
@@ -10,7 +10,8 @@ run_herd_simulation(
   initial_structure = c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30),
   max_years = 100,
   lambda_threshold = 1e-09,
-  show_indicator = TRUE
+  show_indicator = TRUE,
+  assessment_duration
 )
 }
 \arguments{
@@ -54,6 +55,8 @@ reached. Defaults to \code{1e-9}.}
 
 \item{show_indicator}{Logical. Whether to display progress indicators during simulation.
 Defaults to \code{TRUE}.}
+
+\item{assessment_duration}{Numeric. Length of the assessment period (days).}
 }
 \value{
 A named list with two elements:
@@ -137,7 +140,7 @@ cohort_data <- data.table::fread(cohort_path)
 herd_level_data <- data.table::fread(herd_level_path)
 
 # Run herd simulation
-results <- run_herd_simulation(cohort_data, herd_level_data)
+results <- run_herd_simulation(cohort_data, herd_level_data, assessment_duration=200)
 
 # Access results
 print(results$cohort_results)

--- a/man/summarise_offtake.Rd
+++ b/man/summarise_offtake.Rd
@@ -4,7 +4,7 @@
 \alias{summarise_offtake}
 \title{Summarise Offtake and Stock Variation for a Steady-State Year}
 \usage{
-summarise_offtake(size, size_end, size_avg, offtake)
+summarise_offtake(size, size_end, size_avg, offtake, assessment_duration)
 }
 \arguments{
 \item{size}{Numeric vector of length 6. Population at start of year.}

--- a/tests/testthat/test-herd_simulation_core.R
+++ b/tests/testthat/test-herd_simulation_core.R
@@ -110,11 +110,12 @@ test_that("summarise_offtake returns all expected components", {
     size = setNames(rep(100, 6), share_cohorts),
     size_end = setNames(rep(105, 6), share_cohorts),
     size_avg = setNames(rep(102, 6), share_cohorts),
-    offtake = setNames(rep(0.01, 10), cohorts)
+    offtake = setNames(rep(0.01, 10), cohorts),
+    assessment_duration = 200
   )
 
   expect_named(res, c(
-    "stock_variation", "offtake_number", "offtake_share", "offtake_share_avg",
+    "stock_variation", "offtake_number", "offtake_number_assessment", "offtake_share", "offtake_share_avg",
     "offtake_sv_number", "offtake_sv_share", "offtake_sv_share_avg"
   ))
   expect_length(res$offtake_number, 6)


### PR DESCRIPTION
This PR extends the summarise_offtake function to support assessment-period–specific offtake calculations and enable downstream use in the production module.

This change allows offtake to be computed on flexible assessment periods while preserving backward compatibility for annual assessments, and enables more accurate linkage between herd and production modules.

**Changes**
- New function argument: Added `assessment_duration` to `summarise_offtake()` function.
- New returned variable: Introduced `offtake_number_assessment`, scaled to the specified `assessment_duration` rather than annualized values (the herd module default).
(When `assessment_duration` = 365, `offtake_number_assessment` is equivalent to the existing annual `offtake_number`.)

**Downstream integration**
offtake_number_assessment is now available for use in the production module.