### PR TITLE
AFC in days, OP#233

### DIFF
--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -471,7 +471,7 @@ calc_net_energy_growth <- function(
     }
     ret <- ((final_weight - initial_weight) * (a + 0.5 * b * (initial_weight + final_weight))) / duration
   } else if (animal == "PGS") {
-    prot_tissue_frac <- 0.65 
+    prot_tissue_frac <- 0.65
     if (cohort %in% c("FS", "FJ", "MS", "MJ")) {
       cgro <- (prot_tissue_frac * 0.23 * 54) + ((1 - prot_tissue_frac) * 0.9 * 52.3)
       ret <- dwg * cgro
@@ -545,9 +545,9 @@ calc_net_energy_growth <- function(
 #' }
 #'
 #' Lactation energy requirements are applied **only to adult females** and are
-#' scaled by the proportion of milked (\code{milking_fraction}) or lactating 
+#' scaled by the proportion of milked (\code{milking_fraction}) or lactating
 #' (\code{parturition_rate}) animals within the cohort.
-#' 
+#'
 #'
 #' In general form, lactation energy is computed as:
 #'
@@ -555,14 +555,14 @@ calc_net_energy_growth <- function(
 #' energy\_lactation =
 #' (milk\_yield \times milking\_fraction + milk\_for\_offspring)
 #' \times energy\_milk
-#' 
+#'
 #' }
 #'
-#' where: 
-#' 
+#' where:
+#'
 #' \code{energy_milk} is a species-specific coefficient representing the
 #' net energy cost of producing one kilogram of milk (MJ kg\eqn{^{-1}})
-#' 
+#'
 #' Species-specific values of \code{energy_milk} are:
 #' \itemize{
 #'   \item \code{CTL}, \code{BFL}: estimated as a function of milk fat content,
@@ -571,27 +571,27 @@ calc_net_energy_growth <- function(
 #'   \item \code{SHP}: 4.6 (AFRC, 1993; AFRC, 1995),
 #'   \item \code{GTS}: 3.0 (AFRC, 1998).
 #'   }
-#' 
+#'
 #' \code{milk_for_offspring} is the daily amount of milk required to rear offspring across the year (kg day\eqn{^{-1}}).
 #' It is calculated assuming that **5 kg of milk are required for each kilogram of live-weight gain up to weaning**, using the equation below.
-#' 
+#'
 #' \deqn{
 #' milk\_for\_offspring =
 #' \frac{parturition\_rate \times 5 \times (wkg - ckg)}
 #' {365} \code(AFRC, 1990)
 #' }
 
-#' 
+#'
 #' For \code{SHP} and \code{GTS}, \code{milk_for_offspring} also accounts for
 #' the average number of offspring per birth by multiplying by \code{litsize}.
-#' 
+#'
 #'
 #' \strong{For PGS} — NRC (1998):
 #'
 #' For pigs, lactation energy accounts only for the milk consumed directly by offspring (\code{milk_for_offspring})
 #' adjusted by the fraction of the reproductive cycle spent in lactation (\code{cadj}),
 #' and is calculated as follows:
-#' 
+#'
 #' \deqn{
 #' energy\_lactation =
 #' litsize \times (1 - 0.5 \times dr1)
@@ -601,7 +601,7 @@ calc_net_energy_growth <- function(
 #' \right)
 #' \times cadj
 #' }
-#' 
+#'
 #' where:
 #' \itemize{
 #'   \item \eqn{0.02059} is the coefficient for lactation energy requirement
@@ -615,7 +615,7 @@ calc_net_energy_growth <- function(
 #'   \item \eqn{wkg} and \eqn{ckg} are live weights at weaning and at birth,
 #'     respectively (kg),
 #'    \item \eqn{cadj} is the fraction of the reproductive cycle spent in lactation calculated as
-#'    
+#'
 #'    \deqn{
 #'    cadj = \frac{lact}{idle + gest + lact}
 #'    }
@@ -1049,7 +1049,7 @@ calc_net_energy_fibre <- function(
 #' Pregnancy energy is calculated **only for female cohorts**
 #' (i.e., \code{FA} and \code{FS}) and represents the additional
 #' energy required to support gestation.
-#' 
+#'
 #' For \code{FA}, pregnancy energy requirements are adjusted to account
 #' for the proportion of time animals spend in gestation.
 #'
@@ -1059,7 +1059,7 @@ calc_net_energy_fibre <- function(
 #'
 #' \itemize{
 #'   \item For \strong{CTL and BFL} — IPCC (2006, 2019):
-#'   
+#'
 #'   Pregnancy energy is approximated as 10% of maintenance energy.
 #'   \itemize{
 #'     \item \code{FA}:
@@ -1076,7 +1076,7 @@ calc_net_energy_fibre <- function(
 #'   }
 #'
 #'   \item For \strong{CML} — Wardeh (2004):
-#'   
+#'
 #'   Pregnancy energy is estimated as 12% of maintenance energy.
 #'   \itemize{
 #'     \item \code{FA}:
@@ -1093,7 +1093,7 @@ calc_net_energy_fibre <- function(
 #'   }
 #'
 #'   \item For \strong{SHP and GTS} — IPCC (2006, 2019):
-#'   
+#'
 #'   Pregnancy energy is calculated as a litter-size–dependent fraction
 #'   of maintenance energy.
 #'   \itemize{
@@ -1111,7 +1111,7 @@ calc_net_energy_fibre <- function(
 #'         \item If \eqn{litsize > 2}:
 #'           \deqn{cpreg = 0.150}
 #'       }
-#'     \item \code{FS} - 
+#'     \item \code{FS} -
 #'       Pregnancy energy is calculated using the single-birth coefficient
 #'       and scaled to the proportion of reproductive individuals in the cohort.
 #'       \deqn{
@@ -1122,7 +1122,7 @@ calc_net_energy_fibre <- function(
 #'   }
 #'
 #'   \item For \strong{PGS} — NRC (1998):
-#'   
+#'
 #'   \itemize{
 #'     \item \code{FA}:
 #'       \deqn{
@@ -1214,8 +1214,8 @@ calc_net_energy_pregnancy <- function(
       ret <- 0
     }
   } else if (animal == "PGS") {
-    cgest <- 0.14985 
-    
+    cgest <- 0.14985
+
     if (cohort == "FA") {
       ret <- cgest * litsize * gest / (idle + gest + lact)
 
@@ -1430,7 +1430,6 @@ calc_reg_growth <- function(
 #' Livestock and Manure Management, Equation 10.16.
 #'
 #' @export
-
 calc_total_energy_requirement <- function(
     animal,
     cohort,

--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -28,7 +28,7 @@
 #' @param average_weight Numeric. Average live weight over the cohort stage. Computed by accounting for the share of offtaken animals within the cohort, using their slaughter weight, and the potential final weight of animals that remain in the cohort (kg).
 #' @param milking_fraction Numeric. Share of adult females lactating within the assessment duration. Applies to species = CML, CTL, BFL, SHP, GTS. (fraction).
 #' @param offtake_rate Numeric. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).
-#' @param afc Numeric. Age at first parturition for female breeding animals (years)
+#' @param afc Numeric. Age at first parturition for female breeding animals (days)
 #'
 #' @return Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal
 #' in equilibrium such that body energy is neither gained nor lost.
@@ -76,7 +76,7 @@
 #'   \item \code{FJ}:
 #'     \eqn{cmain = 0.236}
 #'   \item \code{FS}:
-#'     \eqn{cmain = 0.236 \times (1/afc) + 0.217 \times ((afc - 1)/afc)}
+#'     \eqn{cmain = 0.236 \times (365/afc) + 0.217 \times ((afc - 365)/afc)}
 #'   \item \code{MA}:
 #'     \eqn{cmain = 0.217 \times offtake\_rate + (0.217 \times 1.15) \times (1 - offtake\_rate)}
 #'   \item \code{MJ}:
@@ -162,7 +162,7 @@ calc_net_energy_maintenance <- function(
       cmain <- 0.217
     } else if (cohort == "FS") {
       # Weighted by age at first calving (afc)
-      cmain <- (0.236 * (1 / afc)) + (0.217 * ((afc - 1) / afc))
+      cmain <- (0.236 * (365 / afc)) + (0.217 * ((afc - 365) / afc))
     } else if (cohort == "FJ") {
       cmain <- 0.236
     } else if (cohort == "MA") {
@@ -170,8 +170,8 @@ calc_net_energy_maintenance <- function(
       cmain <- 0.217 * offtake_rate + 0.217 * 1.15 * (1 - offtake_rate)
     } else if (cohort == "MS") {
       # Complex weighted average for subadult males
-      cmain <- ((0.217 * offtake_rate + 0.217 * 1.15 * (1 - offtake_rate)) * ((afc - 1) / afc) +
-                  (0.236 * offtake_rate + 0.236 * 1.15 * (1 - offtake_rate)) * (1 / afc))
+      cmain <- ((0.217 * offtake_rate + 0.217 * 1.15 * (1 - offtake_rate)) * ((afc - 365) / afc) +
+                  (0.236 * offtake_rate + 0.236 * 1.15 * (1 - offtake_rate)) * (365 / afc))
     } else if (cohort == "MJ") {
       cmain <- 0.236 * offtake_rate + 0.236 * 1.15 * (1 - offtake_rate)
     }
@@ -1364,7 +1364,6 @@ calc_reg_growth <- function(
 #' @param neegg Numeric. Net energy for egg production.
 #' @param reg Ratio of net energy available for growth in a diet to digestible energy consumed (fraction)
 #' @param diet_dig Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)
-#' @param afc Numeric. Age at first parturition for female breeding animals (years)
 #'
 #' @return Numeric. Total daily energy requirement (MJ/head/day). For CTL, BFL, SHP and GTS
 #'   this is expressed as **gross energy intake requirement (GE)**. For CML and PGS
@@ -1445,13 +1444,12 @@ calc_total_energy_requirement <- function(
     nefibre,
     neegg,
     reg,
-    diet_dig,
-    afc
+    diet_dig
 ) {
   # Validate inputs
   validate_total_energy_inputs(
     animal, cohort, nemain, neact, nelact, nework, nepreg,
-    rem, negrow, nefibre, neegg, reg, diet_dig, afc
+    rem, negrow, nefibre, neegg, reg, diet_dig
   )
   # Cattle, buffalo: sum maintenance, activity, lactation, work, pregnancy, growth
   if (animal %in% c("CTL", "BFL")) {

--- a/R/nitrogen_balance_core_model.R
+++ b/R/nitrogen_balance_core_model.R
@@ -57,7 +57,7 @@ compute_nitrogen_intake <- function(dmi, diet_nitrogen) {
 #' @param parturition_rate Numeric. Numeric. Average annual number of parturitions per female animal (fraction). At herd level, calculated as offspring delivered divided by the number of adult females.
 #' @param wkg Numeric. Live weight of the animal at weaning (kg)
 #' @param ckg Numeric. Live weight of the animal at birth (kg).
-#' @param afc Numeric. Age at first parturition for female breeding animals (years)
+#' @param afc Numeric. Age at first parturition for female breeding animals (days)
 #'
 #' @return Numeric.  Daily nitrogen retention in animal body tissues and products (e.g., growth, pregnancy, milk...) (kg N/head/day)
 #' 
@@ -167,7 +167,7 @@ compute_nitrogen_retention <- function(
     } else if (cohort == "FS") {
       return(
         0.025 * dwg +
-          (1 / afc) * (
+          (365 / afc) * (
             (0.025 * litsize * parturition_rate * (wkg - ckg) / 0.98 +
                0.025 * litsize * parturition_rate * ckg) / 365
           )

--- a/R/run_energy_requirements.R
+++ b/R/run_energy_requirements.R
@@ -150,8 +150,7 @@ run_energy_requirements <- function(data) {
     nefibre = nefibre,
     neegg = 0,
     reg = reg,
-    diet_dig = diet_dig,
-    afc = afc
+    diet_dig = diet_dig
   ), by = .I]
 
   # 11. Dry matter intake (kg DM/day)

--- a/R/validate_energy_requirements_core_model.R
+++ b/R/validate_energy_requirements_core_model.R
@@ -340,8 +340,7 @@ validate_total_energy_inputs <- function(
     nefibre,
     neegg,
     reg,
-    diet_dig,
-    afc
+    diet_dig
 ) {
   validate_animal_species(animal)
   validate_cohort_code(cohort)
@@ -372,11 +371,6 @@ validate_total_energy_inputs <- function(
     }
     validate_scalar_numeric(rem, "rem")
     validate_scalar_numeric(reg, "reg")
-  }
-
-  # Validate afc for sheep and goats
-  if (animal %in% c("SHP", "GTS")) {
-    if (!is.na(afc)) validate_positive_numeric(afc, "afc")
   }
 }
 

--- a/R/validate_nitrogen_balance_core_model.R
+++ b/R/validate_nitrogen_balance_core_model.R
@@ -102,8 +102,8 @@ validate_nitrogen_retention_inputs <- function(
   if (!is.na(ckg) && (ckg < 0 || ckg > 100)) {
     cli::cli_abort("{.arg ckg} must be between 0 and 100.")
   }
-  if (!is.na(afc) && (afc < 0.3 || afc > 9)) {
-    cli::cli_abort("{.arg afc} must be between 0.3 and 9")
+  if (!is.na(afc) && (afc < 110 || afc > 3300)) {
+    cli::cli_abort("{.arg afc} must be between 110 and 3300")
   }
 
   # Enforce configured bounds

--- a/man/calc_net_energy_maintenance.Rd
+++ b/man/calc_net_energy_maintenance.Rd
@@ -42,7 +42,7 @@ production stage of the animals. Supported values include:
 
 \item{offtake_rate}{Numeric. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).}
 
-\item{afc}{Numeric. Age at first parturition for female breeding animals (years)}
+\item{afc}{Numeric. Age at first parturition for female breeding animals (days)}
 }
 \value{
 Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal
@@ -97,7 +97,7 @@ weighted average to account for:
 \item \code{FJ}:
 \eqn{cmain = 0.236}
 \item \code{FS}:
-\eqn{cmain = 0.236 \times (1/afc) + 0.217 \times ((afc - 1)/afc)}
+\eqn{cmain = 0.236 \times (365/afc) + 0.217 \times ((afc - 365)/afc)}
 \item \code{MA}:
 \eqn{cmain = 0.217 \times offtake\_rate + (0.217 \times 1.15) \times (1 - offtake\_rate)}
 \item \code{MJ}:

--- a/man/calc_total_energy_requirement.Rd
+++ b/man/calc_total_energy_requirement.Rd
@@ -17,8 +17,7 @@ calc_total_energy_requirement(
   nefibre,
   neegg,
   reg,
-  diet_dig,
-  afc
+  diet_dig
 )
 }
 \arguments{
@@ -65,8 +64,6 @@ production stage of the animals. Supported values include:
 \item{reg}{Ratio of net energy available for growth in a diet to digestible energy consumed (fraction)}
 
 \item{diet_dig}{Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)}
-
-\item{afc}{Numeric. Age at first parturition for female breeding animals (years)}
 }
 \value{
 Numeric. Total daily energy requirement (MJ/head/day). For CTL, BFL, SHP and GTS

--- a/man/compute_nitrogen_retention.Rd
+++ b/man/compute_nitrogen_retention.Rd
@@ -57,7 +57,7 @@ production stage of the animals. Supported values include:
 
 \item{ckg}{Numeric. Live weight of the animal at birth (kg).}
 
-\item{afc}{Numeric. Age at first parturition for female breeding animals (years)}
+\item{afc}{Numeric. Age at first parturition for female breeding animals (days)}
 }
 \value{
 Numeric.  Daily nitrogen retention in animal body tissues and products (e.g., growth, pregnancy, milk...) (kg N/head/day)

--- a/tests/testthat/test-energy_requirements_core.R
+++ b/tests/testthat/test-energy_requirements_core.R
@@ -30,7 +30,7 @@ test_that("calc_net_energy_maintenance handles sheep with age at first calving",
     animal = "SHP", cohort = "FS", average_weight = 40,
     afc = 400
   )
-  expected <- (40^0.75) * ((0.236 * (1/400)) + (0.217 * (399/400)))
+  expected <- (40^0.75) * ((0.236 * (365/400)) + (0.217 * ((400-365)/400)))
   expect_equal(result, expected)
 
   # Test adult female
@@ -421,7 +421,7 @@ test_that("calc_total_energy_requirement returns correct values for cattle", {
   result <- calc_total_energy_requirement(
     animal = "CTL", cohort = "FA",
     nemain = 15.0, neact = 3.0, nelact = 8.0, nework = 0, nepreg = 1.5,
-    rem = 0.6, negrow = 0, nefibre = 0, neegg = 0, reg = 0.5, diet_dig = 0.65, afc = 730
+    rem = 0.6, negrow = 0, nefibre = 0, neegg = 0, reg = 0.5, diet_dig = 0.65
   )
   expected <- (((15.0 + 3.0 + 8.0 + 0 + 1.5) / 0.6) + (0 / 0.5)) / 0.65
   expect_equal(result, expected)
@@ -431,7 +431,7 @@ test_that("calc_total_energy_requirement handles sheep with fibre", {
   result <- calc_total_energy_requirement(
     animal = "SHP", cohort = "FA",
     nemain = 8.0, neact = 1.5, nelact = 4.0, nework = 0, nepreg = 1.0,
-    rem = 0.55, negrow = 0, nefibre = 0.2, neegg = 0, reg = 0.45, diet_dig = 0.60, afc = 400
+    rem = 0.55, negrow = 0, nefibre = 0.2, neegg = 0, reg = 0.45, diet_dig = 0.60
   )
   expected <- (((8.0 + 1.5 + 4.0 + 1.0) / 0.55) + ((0 + 0.2) / 0.45)) / 0.60
   expect_equal(result, expected)
@@ -442,7 +442,7 @@ test_that("calc_total_energy_requirement handles different species", {
   result <- calc_total_energy_requirement(
     animal = "CML", cohort = "FA",
     nemain = 12.0, neact = 2.0, nelact = 6.0, nework = 1.0, nepreg = 1.5,
-    rem = NA, negrow = 0, nefibre = 0.3, neegg = 0, reg = NA, diet_dig = 0.70, afc = 730
+    rem = NA, negrow = 0, nefibre = 0.3, neegg = 0, reg = NA, diet_dig = 0.70
   )
   expected <- 12.0 + 2.0 + 6.0 + 1.0 + 0.3 + 1.5 + 0
   expect_equal(result, expected)
@@ -451,7 +451,7 @@ test_that("calc_total_energy_requirement handles different species", {
   result <- calc_total_energy_requirement(
     animal = "PGS", cohort = "FA",
     nemain = 10.0, neact = 1.0, nelact = 5.0, nework = 0, nepreg = 2.0,
-    rem = NA, negrow = 0, nefibre = 0, neegg = 0, reg = NA, diet_dig = 0.75, afc = 365
+    rem = NA, negrow = 0, nefibre = 0, neegg = 0, reg = NA, diet_dig = 0.75
   )
   expected <- 10.0 + 1.0 + 5.0 + 2.0 + 0
   expect_equal(result, expected)

--- a/tests/testthat/test-nitrogen_balance_core.R
+++ b/tests/testthat/test-nitrogen_balance_core.R
@@ -77,7 +77,7 @@ test_that("retention for pigs FS cohort includes growth and reproductive", {
     "PGS","FS",
     dwg = 0.5,
     litsize = 12, parturition_rate = 2.2,
-    wkg = 20, ckg = 1, afc = 1
+    wkg = 20, ckg = 1, afc = 365
   )
   expect_gt(val, 0)
 })


### PR DESCRIPTION
The following codes were modified to use AFC (age_first_parturition) in days, to be consistent with other time periods used in the package (OP ticket #233):
- Energy_requirements_core_model.R
- Nitrogen_balance_core_model.R
- validate_energy_requirements_core_model.R
- validate_nitrogen_balance_core_model.R
- test_energy_requirements_core.R
- test_nitrogen_balance_core.R

1. Function **calc_net_energy_maintenance** and **compute_nitrogen_retention** were modified to use AFC in days rather than years.
2. Function **calc_total_energy_requirement** was modified to remove AFC from the list of arguments, as it doesn't use it anymore.
3. Validations and tests were changed accordingly. 
4. The roxygen files associated with the edited functions were updated. 
