### PR TITLE
Refactor calc_cohort_weights: remove species logic and helper function

### DIFF
--- a/R/run_weights.R
+++ b/R/run_weights.R
@@ -68,16 +68,14 @@ run_weights_calculations <- function(data) {
   required_cols <- c(
     "cohort",
     "duration",
-    "Animal_short",
     "offtake_rate",
     "AFKG", # Adult female weight
     "AMKG", # Adult male weight
     "ckg", # Birth weight
     "MFSKG", # Slaughter weight female
     "MMSKG", # Slaughter weight male
-    "wkg", # Weaning weight (must be provided in input data)
-    "afc", # Age at first calving
-    "WA" # Animal age at current stage
+    "wkg" # Weaning weight (must be provided in input data)
+
   )
   missing_cols <- setdiff(required_cols, names(data))
   if (length(missing_cols) > 0) {
@@ -88,16 +86,13 @@ run_weights_calculations <- function(data) {
   data[, c(
     "initial_weight", "potential_final_weight", "slaughter_weight"
   ) := calc_cohort_weights(
-    animal = Animal_short,
     cohort = cohort,
     adult_fem_weight = AFKG,
     adult_mal_weight = AMKG,
     birth_weight = ckg,
     slaughter_weight_fem = MFSKG,
     slaughter_weight_mal = MMSKG,
-    weaning_weight = wkg,
-    age_first_calving = afc,
-    animal_age = WA
+    weaning_weight = wkg
   ),
   by = .I
   ]

--- a/R/validate_herd_simulation_core_model.R
+++ b/R/validate_herd_simulation_core_model.R
@@ -194,16 +194,13 @@ validate_offtake_summary_inputs <- function(
 #'
 #' @noRd
 validate_cohort_weight_inputs <- function(
-    animal, cohort,
+    cohort,
     adult_fem_weight, adult_mal_weight,
     birth_weight,
     slaughter_weight_fem, slaughter_weight_mal,
-    weaning_weight,
-    age_first_calving,
-    animal_age
+    weaning_weight
 ) {
   # Character inputs
-  validate_scalar_character(animal, "animal")
   validate_scalar_character(cohort, "cohort")
 
   # Numeric inputs (allow NA)
@@ -213,9 +210,7 @@ validate_cohort_weight_inputs <- function(
     birth_weight = birth_weight,
     slaughter_weight_fem = slaughter_weight_fem,
     slaughter_weight_mal = slaughter_weight_mal,
-    weaning_weight = weaning_weight,
-    age_first_calving = age_first_calving,
-    animal_age = animal_age
+    weaning_weight = weaning_weight
   )
 
   for (arg_name in names(args)) {

--- a/R/weights_core_model.R
+++ b/R/weights_core_model.R
@@ -3,16 +3,6 @@
 #' Attributes and/or compute initial, potential final, and slaughter live weight for
 #' a given cohort and animal species
 #'
-#' @param animal Character. Code identifying the livestock species.
-#'   Supported values include:
-#'   \itemize{
-#'     \item \code{PGS}: pigs
-#'     \item \code{CML}: camels
-#'     \item \code{CTL}: cattle
-#'     \item \code{BFL}: buffalo
-#'     \item \code{SHP}: sheep
-#'     \item \code{GTS}: goats
-#'   }
 #' @param cohort Character scalar. Sex- and age-specific cohort code describing the
 #'   production stage of the animals. Supported values include:
 #'   \describe{
@@ -36,7 +26,7 @@
 #'   \item{potential_final_weight}{Numeric. Potential final live weight attainable at the end of the cohort stage in the absence of offtake (kg). (For juveniles: equals weaning weight; For subadults: equals adult live weight; For adults: equals adult live weight)}
 #'   \item{slaughter_weight}{Numeric. Live weight at slaughter for animals removed from the cohort (kg).}
 #' }
-#' 
+#'
 #' @details
 #' The function attributes weights according to cohort and animal type:
 #'
@@ -65,8 +55,7 @@
 #'     \item \code{slaughter_weight} equals the adult weight for the cohort sex
 #'   }
 #' }
-#' 
-#' 
+#'
 #' @export
 calc_cohort_weights <- function(
     cohort,
@@ -90,15 +79,14 @@ calc_cohort_weights <- function(
     initial_weight <- birth_weight
     potential_final_weight <- slaughter_weight <- weaning_weight
     adult_weight <- if (cohort == "FJ") adult_fem_weight else adult_mal_weight
-    
 
     # Subadult cohorts
   } else if (cohort %in% c("FS", "MS")) {
 
-      initial_weight <- weaning_weight
-      adult_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
-      potential_final_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
-      slaughter_weight <- if (cohort == "FS") slaughter_weight_fem else slaughter_weight_mal
+    initial_weight <- weaning_weight
+    adult_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
+    potential_final_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
+    slaughter_weight <- if (cohort == "FS") slaughter_weight_fem else slaughter_weight_mal
 
     # Adult cohorts
   } else if (cohort == "FA") {
@@ -131,9 +119,9 @@ calc_cohort_weights <- function(
 #'   \item{average_weight}{Numeric. Average live weight over the cohort stage. Computed by accounting for the share of offtaken animals within the cohort, using their slaughter weight, and the potential final weight of animals that remain in the cohort (kg).}
 #'   \item{final_weight}{Numeric. Live weight at the end of the cohort stage, accounting for both surviving and offtaken animals. Computed in the GLEAM pipeline as a weighted average of the potential final weight of surviving animals and the slaughter weight of offtaken animals, based on the offtake rate (kg).}
 #' }
-#' 
+#'
 #' @details
-#' The calculation of \code{average_weight} and \code{final_weight} is performed considering that 
+#' The calculation of \code{average_weight} and \code{final_weight} is performed considering that
 #' a fraction of animals is removed (offtake) during the cohort stage, while the
 #' remaining animals reach the potential final live weight.
 #'

--- a/R/weights_core_model.R
+++ b/R/weights_core_model.R
@@ -29,8 +29,6 @@
 #' @param slaughter_weight_fem Numeric. Slaughter weight of female sub-adult animals (kg).
 #' @param slaughter_weight_mal Numeric. Slaughter weight of male sub-adult animals (kg).
 #' @param weaning_weight Numeric. Live weight of the animal at weaning (kg)
-#' @param age_first_calving Numeric. Age at first parturition for female breeding animals (years)
-#' @param animal_age Numeric. Average age of the juvenile animals at weaning (days)
 #'
 #' @return A named list with:
 #' \describe{
@@ -71,26 +69,18 @@
 #' 
 #' @export
 calc_cohort_weights <- function(
-    animal, cohort,
+    cohort,
     adult_fem_weight = NA_real_, adult_mal_weight = NA_real_,
     birth_weight = NA_real_, slaughter_weight_fem = NA_real_,
-    slaughter_weight_mal = NA_real_, weaning_weight = NA_real_,
-    age_first_calving = NA_real_, animal_age = NA_real_
+    slaughter_weight_mal = NA_real_, weaning_weight = NA_real_
 ) {
   validate_cohort_weight_inputs(
-    animal, cohort,
+    cohort,
     adult_fem_weight, adult_mal_weight,
     birth_weight,
     slaughter_weight_fem, slaughter_weight_mal,
-    weaning_weight,
-    age_first_calving,
-    animal_age
+    weaning_weight
   )
-
-  # Helper function for growing weight
-  grow_weight <- function(adult_weight) {
-    ((adult_weight - birth_weight) / age_first_calving) * animal_age + birth_weight
-  }
 
   # Defaults
   initial_weight <- potential_final_weight <- slaughter_weight <- NA_real_
@@ -98,23 +88,17 @@ calc_cohort_weights <- function(
   # Juvenile cohorts
   if (cohort %in% c("FJ", "MJ")) {
     initial_weight <- birth_weight
-    if (animal %in% c("PGS", "CML")) {
-      potential_final_weight <- slaughter_weight <- weaning_weight
-    } else {
-      adult_weight <- if (cohort == "FJ") adult_fem_weight else adult_mal_weight
-      potential_final_weight <- slaughter_weight <- grow_weight(adult_weight)
-    }
+    potential_final_weight <- slaughter_weight <- weaning_weight
+    adult_weight <- if (cohort == "FJ") adult_fem_weight else adult_mal_weight
+    
 
     # Subadult cohorts
   } else if (cohort %in% c("FS", "MS")) {
-    if (animal %in% c("PGS", "CML")) {
+
       initial_weight <- weaning_weight
-    } else {
       adult_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
-      initial_weight <- grow_weight(adult_weight)
-    }
-    potential_final_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
-    slaughter_weight <- if (cohort == "FS") slaughter_weight_fem else slaughter_weight_mal
+      potential_final_weight <- if (cohort == "FS") adult_fem_weight else adult_mal_weight
+      slaughter_weight <- if (cohort == "FS") slaughter_weight_fem else slaughter_weight_mal
 
     # Adult cohorts
   } else if (cohort == "FA") {

--- a/man/calc_cohort_weights.Rd
+++ b/man/calc_cohort_weights.Rd
@@ -5,30 +5,16 @@
 \title{Calculate Live Weights by Cohort and at different lifestage}
 \usage{
 calc_cohort_weights(
-  animal,
   cohort,
   adult_fem_weight = NA_real_,
   adult_mal_weight = NA_real_,
   birth_weight = NA_real_,
   slaughter_weight_fem = NA_real_,
   slaughter_weight_mal = NA_real_,
-  weaning_weight = NA_real_,
-  age_first_calving = NA_real_,
-  animal_age = NA_real_
+  weaning_weight = NA_real_
 )
 }
 \arguments{
-\item{animal}{Character. Code identifying the livestock species.
-Supported values include:
-\itemize{
-\item \code{PGS}: pigs
-\item \code{CML}: camels
-\item \code{CTL}: cattle
-\item \code{BFL}: buffalo
-\item \code{SHP}: sheep
-\item \code{GTS}: goats
-}}
-
 \item{cohort}{Character scalar. Sex- and age-specific cohort code describing the
 production stage of the animals. Supported values include:
 \describe{
@@ -51,10 +37,6 @@ production stage of the animals. Supported values include:
 \item{slaughter_weight_mal}{Numeric. Slaughter weight of male sub-adult animals (kg).}
 
 \item{weaning_weight}{Numeric. Live weight of the animal at weaning (kg)}
-
-\item{age_first_calving}{Numeric. Age at first parturition for female breeding animals (years)}
-
-\item{animal_age}{Numeric. Average age of the juvenile animals at weaning (days)}
 }
 \value{
 A named list with:

--- a/tests/testthat/test-herd_simulation_core.R
+++ b/tests/testthat/test-herd_simulation_core.R
@@ -124,11 +124,10 @@ test_that("summarise_offtake returns all expected components", {
 # ---- test calc_cohort_weights ----
 test_that("calc_cohort_weights returns valid weights for juvenile non-pig", {
   result <- calc_cohort_weights(
-    animal = "CTL", cohort = "FJ",
+    cohort = "FJ",
     adult_fem_weight = 500, adult_mal_weight = 600,
     birth_weight = 35, slaughter_weight_fem = 480,
-    slaughter_weight_mal = 550, weaning_weight = 90,
-    age_first_calving = 730, animal_age = 200
+    slaughter_weight_mal = 550, weaning_weight = 90
   )
 
   expect_named(result, c("initial_weight", "potential_final_weight", "slaughter_weight"))
@@ -140,11 +139,10 @@ test_that("calc_cohort_weights returns valid weights for juvenile non-pig", {
 
 test_that("calc_cohort_weights returns correct weights for adult female", {
   result <- calc_cohort_weights(
-    animal = "SHP", cohort = "FA",
+    cohort = "FA",
     adult_fem_weight = 70, adult_mal_weight = 90,
     birth_weight = 4, slaughter_weight_fem = 65,
-    slaughter_weight_mal = 85, weaning_weight = 18,
-    age_first_calving = 400, animal_age = 300
+    slaughter_weight_mal = 85, weaning_weight = 18
   )
 
   expect_equal(result$initial_weight, 70)
@@ -154,11 +152,10 @@ test_that("calc_cohort_weights returns correct weights for adult female", {
 
 test_that("calc_cohort_weights handles pig juvenile with weaning weight", {
   result <- calc_cohort_weights(
-    animal = "PGS", cohort = "FJ",
+    cohort = "FJ",
     adult_fem_weight = 180, adult_mal_weight = 220,
     birth_weight = 1.5, slaughter_weight_fem = 160,
-    slaughter_weight_mal = 200, weaning_weight = 10,
-    age_first_calving = 365, animal_age = 60
+    slaughter_weight_mal = 200, weaning_weight = 10
   )
 
   expect_equal(result$initial_weight, 1.5)


### PR DESCRIPTION
Refactors calc_cohort_weights() to match the new data model by removing species-specific logic and the deprecated helper function. This simplifies the implementation and aligns the function with current user inputs.


In "projects" the reference to this issue is: #221