### PR TITLE
[OP#242] Including the calculation of nework also for adult females (FA)

### DIFF
--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -782,17 +782,19 @@ calc_net_energy_eggs <- function(
 #'     \item \code{MJ}: juvenile males (from birth to weaning)
 #'   }
 #' @param nemain Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal in equilibrium such that body energy is neither gained nor lost. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
-#' @param work_hours Numeric. Mean daily working time per animal for CTL, BFL and CML, expressed as hours worked per head per day (hours/head/day).
-#' @param draught_fraction Numeric. Fraction of adult males involved in draught work (fraction).
+#' @param work_hours_female Numeric. Average daily working time per adult females for CTL, BFL and CML, expressed as hours worked per head per day  (hours/head/day). 
+#' @param work_hours_male Numeric. Average daily working time per adult males for CTL, BFL and CML, expressed as hours worked per head per day  (hours/head/day). 
+#' @param draught_fraction_female Numeric. Fraction of adult females involved in draught work (fraction).
+#' @param draught_fraction_male Numeric. Fraction of adult males involved in draught work (fraction).
 #'
-#' @return Numeric. Energy required for work, used to estimate the energy required for draft power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
+#' @return Numeric. Energy required for work, used to estimate the energy required for draught power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #'
 #'@details
 #' Energy for work (\code{energy_work}) represents the additional energy required
 #' to support \strong{draught power generation} by working animals.
 #'
 #' This component is applied only to draught-capable species and is scaled by
-#' the fraction of adult males involved in draught work (\code{draught_fraction})
+#' the fraction of adult animals involved in draught work (\code{draught_fraction})
 #' and their average daily working time (\code{work_hours}).
 #'
 #' \strong{CTL and BFL} - Bamualim & Kartiarso (1985); IPCC (2006, 2019).
@@ -847,24 +849,34 @@ calc_net_energy_work <- function(
     animal,
     cohort,
     nemain,
-    work_hours,
-    draught_fraction
+    work_hours_female,
+    work_hours_male,
+    draught_fraction_female,
+    draught_fraction_male
 ) {
   # Validate inputs
-  validate_work_inputs(animal, cohort, nemain, work_hours, draught_fraction)
+  validate_work_inputs(animal, cohort, nemain,  
+                       work_hours_female,
+                       work_hours_male,
+                       draught_fraction_female,
+                       draught_fraction_male)
+  
   # Only adult males (MA) work
   if (animal %in% c("CTL", "BFL")) {
-    if (cohort != "MA") {
-      ret <- 0
+    if (cohort == "MA") {
+      ret <- 0.1 * nemain * work_hours_male * draught_fraction_male
+    } else if (cohort == "FA") {  
+      ret <- 0.1 * nemain * work_hours_female * draught_fraction_female
     } else {
-      # 0.1 coefficient: GLEAM standard for work
-      ret <- 0.1 * nemain * work_hours * draught_fraction
+      ret <- 0
     }
   } else if (animal %in% c("CML")) {
-    if (cohort != "MA") {
-      ret <- 0
+    if (cohort == "MA") {
+      ret <- 4 * work_hours_male * draught_fraction_male
+    } else if (cohort == "FA") {  
+      ret <- 4 * work_hours_female * draught_fraction_female
     } else {
-      ret <- 4 * work_hours * draught_fraction
+      ret <- 0
     }
   } else if (animal %in% c("SHP", "GTS", "PGS", "CHK")) {
     ret <- 0 # No work for these species

--- a/R/run_energy_requirements.R
+++ b/R/run_energy_requirements.R
@@ -100,8 +100,10 @@ run_energy_requirements <- function(data) {
     animal = Animal_short,
     cohort = cohort,
     nemain = nemain,
-    work_hours = work_hours,
-    draught_fraction = draught_fraction
+    work_hours_female = work_hours_female,
+    work_hours_male = work_hours_male,
+    draught_fraction_female = draught_fraction_female,
+    draught_fraction_male = draught_fraction_male
   ), by = .I]
 
   # 6. Fibre production energy (MJ/day)

--- a/R/validate_energy_requirements_core_model.R
+++ b/R/validate_energy_requirements_core_model.R
@@ -210,20 +210,28 @@ validate_work_inputs <- function(
     animal,
     cohort,
     nemain,
-    work_hours,
-    draught_fraction
+    work_hours_female,
+    work_hours_male,
+    draught_fraction_female,
+    draught_fraction_male
 ) {
   validate_animal_species(animal)
   validate_cohort_code(cohort)
   validate_positive_numeric(nemain, "nemain")
-  validate_scalar_numeric(work_hours, "work_hours")
-  validate_scalar_numeric(draught_fraction, "draught_fraction")
-  validate_fraction(draught_fraction, "draught_fraction")
-  
+  validate_scalar_numeric(work_hours_female, "work_hours_female")
+  validate_scalar_numeric(work_hours_male, "work_hours_male")
+  validate_scalar_numeric(draught_fraction_female, "draught_fraction_female")
+  validate_fraction(draught_fraction_female, "draught_fraction_female")
+  validate_scalar_numeric(draught_fraction_male, "draught_fraction_male")
+  validate_fraction(draught_fraction_male, "draught_fraction_male")
   
 
-  if (work_hours < 0 || work_hours > 24) {
-    cli::cli_abort("{.arg work_hours} must be between 0 and 24.")
+  if (work_hours_female < 0 || work_hours_female > 24) {
+    cli::cli_abort("{.arg work_hours_female} must be between 0 and 24.")
+  }
+  
+  if (draught_fraction_male < 0 || draught_fraction_male > 24) {
+    cli::cli_abort("{.arg draught_fraction_male} must be between 0 and 24.")
   }
 }
 

--- a/man/calc_net_energy_work.Rd
+++ b/man/calc_net_energy_work.Rd
@@ -4,7 +4,15 @@
 \alias{calc_net_energy_work}
 \title{Calculate Energy for Work}
 \usage{
-calc_net_energy_work(animal, cohort, nemain, work_hours, draught_fraction)
+calc_net_energy_work(
+  animal,
+  cohort,
+  nemain,
+  work_hours_female,
+  work_hours_male,
+  draught_fraction_female,
+  draught_fraction_male
+)
 }
 \arguments{
 \item{animal}{Character. Code identifying the livestock species.
@@ -31,12 +39,16 @@ production stage of the animals. Supported values include:
 
 \item{nemain}{Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal in equilibrium such that body energy is neither gained nor lost. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).}
 
-\item{work_hours}{Numeric. Mean daily working time per animal for CTL, BFL and CML, expressed as hours worked per head per day (hours/head/day).}
+\item{work_hours_female}{Numeric. Average daily working time per adult females for CTL, BFL and CML, expressed as hours worked per head per day  (hours/head/day).}
 
-\item{draught_fraction}{Numeric. Fraction of adult males involved in draught work (fraction).}
+\item{work_hours_male}{Numeric. Average daily working time per adult males for CTL, BFL and CML, expressed as hours worked per head per day  (hours/head/day).}
+
+\item{draught_fraction_female}{Numeric. Fraction of adult females involved in draught work (fraction).}
+
+\item{draught_fraction_male}{Numeric. Fraction of adult males involved in draught work (fraction).}
 }
 \value{
-Numeric. Energy required for work, used to estimate the energy required for draft power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
+Numeric. Energy required for work, used to estimate the energy required for draught power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 }
 \description{
 Computes the \strong{energy requirement for work} (MJ/head/day), defined as the
@@ -48,7 +60,7 @@ Energy for work (\code{energy_work}) represents the additional energy required
 to support \strong{draught power generation} by working animals.
 
 This component is applied only to draught-capable species and is scaled by
-the fraction of adult males involved in draught work (\code{draught_fraction})
+the fraction of adult animals involved in draught work (\code{draught_fraction})
 and their average daily working time (\code{work_hours}).
 
 \strong{CTL and BFL} - Bamualim & Kartiarso (1985); IPCC (2006, 2019).

--- a/tests/testthat/test-energy_requirements_core.R
+++ b/tests/testthat/test-energy_requirements_core.R
@@ -260,7 +260,11 @@ test_that("calc_net_energy_work returns correct values for working animals", {
   # Test cattle adult male
   result <- calc_net_energy_work(
     animal = "CTL", cohort = "MA",
-    nemain = 20.0, work_hours = 4, draught_fraction = 0.3
+    nemain = 20.0, 
+    work_hours_female = 2,
+    work_hours_male = 4,
+    draught_fraction_female = 0.5,
+    draught_fraction_male = 0.3
   )
   expected <- 0.1 * 20.0 * 4 * 0.3
   expect_equal(result, expected)
@@ -268,16 +272,26 @@ test_that("calc_net_energy_work returns correct values for working animals", {
   # Test non-working cohort
   result <- calc_net_energy_work(
     animal = "CTL", cohort = "FA",
-    nemain = 15.0, work_hours = 4, draught_fraction = 0.3
+    nemain = 15.0, 
+    work_hours_female = 2,
+    work_hours_male = 4,
+    draught_fraction_female = 0.5,
+    draught_fraction_male = 0.3
   )
-  expect_equal(result, 0)
+  
+  expected <- 0.1 * 15.0 * 2 * 0.5
+  expect_equal(result, expected)
 })
 
 test_that("calc_net_energy_work handles different species", {
   # Test camelids
   result <- calc_net_energy_work(
     animal = "CML", cohort = "MA",
-    nemain = 18.0, work_hours = 6, draught_fraction = 0.4
+    nemain = 18.0, 
+    work_hours_female = 2,
+    work_hours_male = 6,
+    draught_fraction_female = 0.5,
+    draught_fraction_male = 0.4
   )
   expected <- 4 * 6 * 0.4
   expect_equal(result, expected)
@@ -285,7 +299,11 @@ test_that("calc_net_energy_work handles different species", {
   # Test species that don't work
   result <- calc_net_energy_work(
     animal = "SHP", cohort = "MA",
-    nemain = 10.0, work_hours = 4, draught_fraction = 0.3
+    nemain = 10.0,  
+    work_hours_female = 8,
+    work_hours_male = 4,
+    draught_fraction_female = 0.3,
+    draught_fraction_male = 0.3
   )
   expect_equal(result, 0)
 })


### PR DESCRIPTION
This pull request extends the calculation of network energy to also include adult females (FA).

**Key updates:**

1. The scientific function `calc_net_energy_work` was updated to account for FA.
3. Tests and validation procedures were revised accordingly.
5. Documentation was updated to reflect the new arguments and functionality.

**Description of the change**

The input variables `work_hours` and `draught_fraction` are now treated as sex-specific, herd-level inputs and are assigned separately to adult male and adult female cohorts:
- `work_hours_male`
- `work_hours_female`
- `draught_fraction_male`
- `draught_fraction_female`

These variables are now included as primary inputs to the function.

The function logic has been updated accordingly to:

1. Use sex-specific inputs when calculating net energy for work, and
2. Explicitly handle conditions for adult female animals in addition to adult males.

This ensures that work-related energy requirements are calculated correctly for both adult male and adult female cohorts.