### PR TITLE
[OP#249] Adding condition to return Ym as 0 for juveniles

### DIFF
--- a/R/directemissions_enteric_core_model.R
+++ b/R/directemissions_enteric_core_model.R
@@ -50,13 +50,13 @@
 #'       \item Other cohorts: \deqn{ym = 0.39}
 #'     }
 #' }
-#'
+#' 
 #'
 #' @references
 #' Opio, C., Gerber, P., Mottet, A., Falcucci, A., Tempio, G.,
 #' MacLeod, M., Vellinga, T., Henderson, B. & Steinfeld, H. (2013).
 #' *Greenhouse gas emissions from ruminant supply chains – A global life cycle assessment*. Food and Agriculture Organization of the United Nations (FAO), Rome.
-#'
+#' 
 #' IPCC. (2019). *2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories*, Chapter 10: Emissions from
 #' Livestock and Manure Management, Equation 10.21.
 #' 
@@ -70,19 +70,40 @@ compute_methane_conversion_factor <- function(
     diet_dig
 ) {
   validate_ym_inputs(animal, cohort, diet_dig)
+  
   if (animal %in% c("CTL", "BFL")) {
-    ret = 9.75 - 0.05 * diet_dig * 100
-  } else if (animal %in% c("SHP", "GTS", "CML")) {
-    if (cohort %in% c("FS", "MS", "FJ", "MJ")) {
-      ret = 7.75 - 0.05 * diet_dig * 100
+    
+    if (cohort %in% c("FJ", "MJ")) {
+      ret <- 0
     } else {
       ret = 9.75 - 0.05 * diet_dig * 100
     }
-  } else if (animal %in% c("PGS")) {
-    ret <- if (cohort %in% c("FA", "MA")) 1.01 else 0.39
-  } else if (animal == "CHK") {
+    
+    } else if (animal %in% c("SHP", "GTS", "CML")) {
+    
+      if (cohort %in% c("FJ", "MJ")){
+      ret <- 0
+      } else if (cohort %in% c("FS", "MS")) {
+      ret = 7.75 - 0.05 * diet_dig * 100
+      } else {
+      ret = 9.75 - 0.05 * diet_dig * 100
+      }
+      
+    } else if (animal %in% c("PGS")) {
+      
+      if (cohort %in% c("FJ", "MJ")){
+      ret <- 0
+      } else if (cohort %in% c("FS", "MS")) {
+      ret <- 0.39
+      } else {
+      ret <- 1.01
+      }
+    
+    } else if (animal == "CHK") {
+      
     ret <- NA_real_
-  }
+    }
+  
   return(ret)
 }
 

--- a/R/directemissions_enteric_core_model.R
+++ b/R/directemissions_enteric_core_model.R
@@ -162,13 +162,12 @@ compute_methane_conversion_factor <- function(
 #' @export
 compute_daily_enteric_emissions <- function(
     animal,
-    cohort,
     ym,
     ch4_mitigation_factor,
     diet_ge,
     dmi
 ) {
-  validate_enteric_emission_inputs(animal, cohort, ym, ch4_mitigation_factor, diet_ge, dmi)
+  validate_enteric_emission_inputs(animal, ym, ch4_mitigation_factor, diet_ge, dmi)
   if (animal %in% c("CTL", "BFL", "CML", "PGS", "SHP", "GTS")) {
     ret <- diet_ge * dmi * (ym / 100) * ch4_mitigation_factor / 55.65
   } else if (animal == "CHK") {

--- a/R/directemissions_enteric_core_model.R
+++ b/R/directemissions_enteric_core_model.R
@@ -39,24 +39,29 @@
 #'
 #'   \item \strong{For \code{SHP}, \code{GTS} and \code{CML}:}
 #'     \itemize{
-#'       \item \code{JF} and \code{JM} cohorts: \deqn{ym = 7.75 - 0.05 \times (diet\_dig \times 100)}
-#'       \item Other cohorts: \deqn{ym = 9.75 - 0.05 \times (diet\_dig \times 100)}
+#'       \item \code{FA} and \code{MA} cohorts: \deqn{ym = 9.75 - 0.05 \times (diet\_dig \times 100)}
+#'       \item \code{FS} and \code{MS} cohorts: \deqn{ym = 7.75 - 0.05 \times (diet\_dig \times 100)}
 #'     }
 #'
 #'   \item \strong{For \code{PGS}:}
 #'     ym is assigned fixed values by cohort:
 #'     \itemize{
 #'       \item \code{FA} and \code{MA} cohorts: \deqn{ym = 1.01}
-#'       \item Other cohorts: \deqn{ym = 0.39}
+#'        \item \code{FS} and \code{MS} cohorts: \deqn{ym = 0.39}
 #'     }
 #' }
 #' 
+#' ym is returned as 0 for juvenile cohorts (\code{JF}, \code{JM}), assuming negligible enteric methane production before weaning/rumen development.
+#'
 #'
 #' @references
 #' Opio, C., Gerber, P., Mottet, A., Falcucci, A., Tempio, G.,
 #' MacLeod, M., Vellinga, T., Henderson, B. & Steinfeld, H. (2013).
 #' *Greenhouse gas emissions from ruminant supply chains – A global life cycle assessment*. Food and Agriculture Organization of the United Nations (FAO), Rome.
 #' 
+#' Jørgensen, H., Theil, P.K. and Knudsen, K.E.B., (2011). 
+#' *Enteric methane emission from pigs*. In Planet Earth 2011-Global Warming Challenges and Opportunities for Policy and Practice (p. 610 - Table 2). InTech.
+#'
 #' IPCC. (2019). *2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories*, Chapter 10: Emissions from
 #' Livestock and Manure Management, Equation 10.21.
 #' 
@@ -124,16 +129,6 @@ compute_methane_conversion_factor <- function(
 #'     \item \code{GTS}: goats
 #'   }
 #'   
-#' @param cohort Character. Sex- and age-specific cohort code describing the
-#'   production stage of the animals. Supported values include:
-#'   \itemize{
-#'     \item \code{FA}: adult females (from age at first parturition)
-#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
-#'     \item \code{FJ}: juvenile females (from birth to weaning)
-#'     \item \code{MA}: adult males (from age at first breeding)
-#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
-#'     \item \code{MJ}: juvenile males (from birth to weaning)
-#'   }
 #' @param ym Numeric. Methane conversion factor (ym), representing the percentage of gross energy of the feed ration that is converted to CH₄ (percentage).
 #' @param ch4_mitigation_factor Numeric. Dimensionless fraction of baseline enteric methane emissions remaining after mitigation. Applied as a
 #' multiplicative factor to calculated emissions (1 = no mitigation, 0.9 = 10% reduction). Default = 1.

--- a/R/run_directemissions_enteric.R
+++ b/R/run_directemissions_enteric.R
@@ -86,7 +86,6 @@ run_directemissions_enteric <- function(data) {
   # Compute enteric methane emissions (kg CH4/day)
   data[, ch4_enteric := compute_daily_enteric_emissions(
     animal = Animal_short,
-    cohort = cohort,
     ym = ym,
     ch4_mitigation_factor = 1,
     diet_ge = diet_ge,

--- a/R/validate_directemissions_enteric.R
+++ b/R/validate_directemissions_enteric.R
@@ -41,14 +41,12 @@ validate_ym_inputs <- function(
 #' @noRd
 validate_enteric_emission_inputs <- function(
     animal,
-    cohort,
     ym,
     ch4_mitigation_factor,
     diet_ge,
     dmi
 ) {
   validate_scalar_character(animal, "animal")
-  validate_scalar_character(cohort, "cohort")
 
   # Special case: chickens always return NA for now
   if (animal == "CHK") {

--- a/man/compute_daily_enteric_emissions.Rd
+++ b/man/compute_daily_enteric_emissions.Rd
@@ -6,7 +6,6 @@
 \usage{
 compute_daily_enteric_emissions(
   animal,
-  cohort,
   ym,
   ch4_mitigation_factor,
   diet_ge,
@@ -23,17 +22,6 @@ Supported values include:
 \item \code{BFL}: buffalo
 \item \code{SHP}: sheep
 \item \code{GTS}: goats
-}}
-
-\item{cohort}{Character. Sex- and age-specific cohort code describing the
-production stage of the animals. Supported values include:
-\itemize{
-\item \code{FA}: adult females (from age at first parturition)
-\item \code{FS}: sub-adult females (from weaning to age at first parturition)
-\item \code{FJ}: juvenile females (from birth to weaning)
-\item \code{MA}: adult males (from age at first breeding)
-\item \code{MS}: sub-adult males (from weaning to age at first breeding)
-\item \code{MJ}: juvenile males (from birth to weaning)
 }}
 
 \item{ym}{Numeric. Methane conversion factor (ym), representing the percentage of gross energy of the feed ration that is converted to CH₄ (percentage).}

--- a/man/compute_methane_conversion_factor.Rd
+++ b/man/compute_methane_conversion_factor.Rd
@@ -48,22 +48,27 @@ ym is computed using species- and cohort-specific default relationships with die
 
 \item \strong{For \code{SHP}, \code{GTS} and \code{CML}:}
 \itemize{
-\item \code{JF} and \code{JM} cohorts: \deqn{ym = 7.75 - 0.05 \times (diet\_dig \times 100)}
-\item Other cohorts: \deqn{ym = 9.75 - 0.05 \times (diet\_dig \times 100)}
+\item \code{FA} and \code{MA} cohorts: \deqn{ym = 9.75 - 0.05 \times (diet\_dig \times 100)}
+\item \code{FS} and \code{MS} cohorts: \deqn{ym = 7.75 - 0.05 \times (diet\_dig \times 100)}
 }
 
 \item \strong{For \code{PGS}:}
 ym is assigned fixed values by cohort:
 \itemize{
 \item \code{FA} and \code{MA} cohorts: \deqn{ym = 1.01}
-\item Other cohorts: \deqn{ym = 0.39}
+\item \code{FS} and \code{MS} cohorts: \deqn{ym = 0.39}
 }
 }
+
+ym is returned as 0 for juvenile cohorts (\code{JF}, \code{JM}), assuming negligible enteric methane production before weaning/rumen development.
 }
 \references{
 Opio, C., Gerber, P., Mottet, A., Falcucci, A., Tempio, G.,
 MacLeod, M., Vellinga, T., Henderson, B. & Steinfeld, H. (2013).
 \emph{Greenhouse gas emissions from ruminant supply chains – A global life cycle assessment}. Food and Agriculture Organization of the United Nations (FAO), Rome.
+
+Jørgensen, H., Theil, P.K. and Knudsen, K.E.B., (2011).
+\emph{Enteric methane emission from pigs}. In Planet Earth 2011-Global Warming Challenges and Opportunities for Policy and Practice (p. 610 - Table 2). InTech.
 
 IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
 Livestock and Manure Management, Equation 10.21.

--- a/tests/testthat/test-directemissions_enteric_core.R
+++ b/tests/testthat/test-directemissions_enteric_core.R
@@ -43,7 +43,6 @@ test_that("compute_daily_enteric_emissions validates inputs and returns expected
   ym <- compute_methane_conversion_factor("CTL", "FA", 0.6)
   ch4 <- compute_daily_enteric_emissions(
     animal = "CTL",
-    cohort = "FA",
     ym = ym,
     ch4_mitigation_factor = 1,
     diet_ge = 18.4,
@@ -54,17 +53,17 @@ test_that("compute_daily_enteric_emissions validates inputs and returns expected
 
   # Chickens: emissions NA
   ym_ch <- compute_methane_conversion_factor("CHK", "FA", 0.7)
-  ch4_ch <- compute_daily_enteric_emissions("CHK", "FA", ym_ch, 1, 16, 0.1)
+  ch4_ch <- compute_daily_enteric_emissions("CHK", ym_ch, 1, 16, 0.1)
   expect_true(is.na(ch4_ch))
 
   # Zero inputs give zero emissions
-  expect_equal(compute_daily_enteric_emissions("CTL", "FA", 0, 1, 18, 10), 0)
-  expect_equal(compute_daily_enteric_emissions("CTL", "FA", 5, 1, 18, 0), 0)
+  expect_equal(compute_daily_enteric_emissions("CTL", 0, 1, 18, 10), 0)
+  expect_equal(compute_daily_enteric_emissions("CTL", 5, 1, 18, 0), 0)
 
   # Invalid arguments
-  expect_error(compute_daily_enteric_emissions("CTL", "FA", -1, 1, 18, 10))  # ym < 0
-  expect_error(compute_daily_enteric_emissions("CTL", "FA", 5, 1, 0, 10))   # diet_ge <= 0
-  expect_error(compute_daily_enteric_emissions("CTL", "FA", 5, 1, 18, -1))  # dmi < 0
+  expect_error(compute_daily_enteric_emissions("CTL", -1, 1, 18, 10))  # ym < 0
+  expect_error(compute_daily_enteric_emissions("CTL", 5, 1, 0, 10))   # diet_ge <= 0
+  expect_error(compute_daily_enteric_emissions("CTL", 5, 1, 18, -1))  # dmi < 0
 
   # Emissions must be non-negative
   expect_gte(ch4, 0)

--- a/tests/testthat/test-directemissions_enteric_core.R
+++ b/tests/testthat/test-directemissions_enteric_core.R
@@ -17,10 +17,10 @@ test_that("compute_methane_conversion_factor validates inputs and computes YM", 
 
   # Pigs: adult vs juvenile
   expect_equal(compute_methane_conversion_factor("PGS", "FA", 0.65), 1.01)
-  expect_equal(compute_methane_conversion_factor("PGS", "FJ", 0.65), 0.39)
+  expect_equal(compute_methane_conversion_factor("PGS", "FJ", 0.65), 0)
 
   # Small ruminants/camels: juvenile/subadult vs adult
-  ym_juv <- compute_methane_conversion_factor("SHP", "FJ", 0.65) # 7.75 rule
+  ym_juv <- compute_methane_conversion_factor("SHP", "FJ", 0) 
   ym_adult <- compute_methane_conversion_factor("SHP", "FA", 0.65) # 9.75 rule
   expect_lt(ym_juv, ym_adult)
 


### PR DESCRIPTION
Main changes:
1. This PR updates the enteric methane module to explicitly return Ym = 0 for juvenile cohorts (FJ, MJ) across species in the `compute_methane_conversion_factor() `function, reflecting the assumption of negligible enteric methane emissions before weaning/rumen development.
2. A minor change also included removing an unused argument (`cohort`) from the function `compute_daily_enteric_emissions()`
3. Documentation, tests and validations were also updated
