### PR TITLE
[OP#253 & #254] Removing unused argument 'cohort' as function argument

### DIFF
--- a/R/directemissions_enteric_core_model.R
+++ b/R/directemissions_enteric_core_model.R
@@ -103,16 +103,6 @@ compute_methane_conversion_factor <- function(
 #'     \item \code{GTS}: goats
 #'   }
 #'   
-#' @param cohort Character. Sex- and age-specific cohort code describing the
-#'   production stage of the animals. Supported values include:
-#'   \itemize{
-#'     \item \code{FA}: adult females (from age at first parturition)
-#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
-#'     \item \code{FJ}: juvenile females (from birth to weaning)
-#'     \item \code{MA}: adult males (from age at first breeding)
-#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
-#'     \item \code{MJ}: juvenile males (from birth to weaning)
-#'   }
 #' @param ym Numeric. Methane conversion factor (ym), representing the percentage of gross energy of the feed ration that is converted to CH₄ (percentage).
 #' @param ch4_mitigation_factor Numeric. Dimensionless fraction of baseline enteric methane emissions remaining after mitigation. Applied as a
 #' multiplicative factor to calculated emissions (1 = no mitigation, 0.9 = 10% reduction). Default = 1.
@@ -141,13 +131,12 @@ compute_methane_conversion_factor <- function(
 #' @export
 compute_daily_enteric_emissions <- function(
     animal,
-    cohort,
     ym,
     ch4_mitigation_factor,
     diet_ge,
     dmi
 ) {
-  validate_enteric_emission_inputs(animal, cohort, ym, ch4_mitigation_factor, diet_ge, dmi)
+  validate_enteric_emission_inputs(animal, ym, ch4_mitigation_factor, diet_ge, dmi)
   if (animal %in% c("CTL", "BFL", "CML", "PGS", "SHP", "GTS")) {
     ret <- diet_ge * dmi * (ym / 100) * ch4_mitigation_factor / 55.65
   } else if (animal == "CHK") {

--- a/R/energy_requirements_core_model.R
+++ b/R/energy_requirements_core_model.R
@@ -1355,16 +1355,6 @@ calc_reg_growth <- function(
 #'     \item \code{SHP}: sheep
 #'     \item \code{GTS}: goats
 #'   }
-#' @param cohort Character. Sex- and age-specific cohort code describing the
-#'   production stage of the animals. Supported values include:
-#'   \itemize{
-#'     \item \code{FA}: adult females (from age at first parturition)
-#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
-#'     \item \code{FJ}: juvenile females (from birth to weaning)
-#'     \item \code{MA}: adult males (from age at first breeding)
-#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
-#'     \item \code{MJ}: juvenile males (from birth to weaning)
-#'   }
 #' @param nemain Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal in equilibrium such that body energy is neither gained nor lost. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #' @param neact Numeric. Energy required for activity, defined as the amount of energy needed to obtain food, water and shelter (example stall, grazing large areas). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #' @param nelact Numeric. Energy required for lactation. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
@@ -1444,7 +1434,6 @@ calc_reg_growth <- function(
 #' @export
 calc_total_energy_requirement <- function(
     animal,
-    cohort,
     nemain,
     neact,
     nelact,
@@ -1459,7 +1448,7 @@ calc_total_energy_requirement <- function(
 ) {
   # Validate inputs
   validate_total_energy_inputs(
-    animal, cohort, nemain, neact, nelact, nework, nepreg,
+    animal, nemain, neact, nelact, nework, nepreg,
     rem, negrow, nefibre, neegg, reg, diet_dig
   )
   # Cattle, buffalo: sum maintenance, activity, lactation, work, pregnancy, growth

--- a/R/run_directemissions_enteric.R
+++ b/R/run_directemissions_enteric.R
@@ -86,7 +86,6 @@ run_directemissions_enteric <- function(data) {
   # Compute enteric methane emissions (kg CH4/day)
   data[, ch4_enteric := compute_daily_enteric_emissions(
     animal = Animal_short,
-    cohort = cohort,
     ym = ym,
     ch4_mitigation_factor = 1,
     diet_ge = diet_ge,

--- a/R/run_energy_requirements.R
+++ b/R/run_energy_requirements.R
@@ -141,7 +141,6 @@ run_energy_requirements <- function(data) {
   # 10. Total ME requirement (MJ/day)
   data[, getot := calc_total_energy_requirement(
     animal = Animal_short,
-    cohort = cohort,
     nemain = nemain,
     neact = neact,
     nelact = nelact,

--- a/R/validate_directemissions_enteric.R
+++ b/R/validate_directemissions_enteric.R
@@ -41,14 +41,12 @@ validate_ym_inputs <- function(
 #' @noRd
 validate_enteric_emission_inputs <- function(
     animal,
-    cohort,
     ym,
     ch4_mitigation_factor,
     diet_ge,
     dmi
 ) {
   validate_scalar_character(animal, "animal")
-  validate_scalar_character(cohort, "cohort")
 
   # Special case: chickens always return NA for now
   if (animal == "CHK") {

--- a/R/validate_energy_requirements_core_model.R
+++ b/R/validate_energy_requirements_core_model.R
@@ -337,7 +337,6 @@ validate_reg_inputs <- function(
 #' @noRd
 validate_total_energy_inputs <- function(
     animal,
-    cohort,
     nemain,
     neact,
     nelact,
@@ -351,7 +350,6 @@ validate_total_energy_inputs <- function(
     diet_dig
 ) {
   validate_animal_species(animal)
-  validate_cohort_code(cohort)
   validate_scalar_numeric(nemain, "nemain")
   validate_scalar_numeric(neact, "neact")
   validate_scalar_numeric(nelact, "nelact")

--- a/man/calc_total_energy_requirement.Rd
+++ b/man/calc_total_energy_requirement.Rd
@@ -6,7 +6,6 @@
 \usage{
 calc_total_energy_requirement(
   animal,
-  cohort,
   nemain,
   neact,
   nelact,
@@ -30,17 +29,6 @@ Supported values include:
 \item \code{BFL}: buffalo
 \item \code{SHP}: sheep
 \item \code{GTS}: goats
-}}
-
-\item{cohort}{Character. Sex- and age-specific cohort code describing the
-production stage of the animals. Supported values include:
-\itemize{
-\item \code{FA}: adult females (from age at first parturition)
-\item \code{FS}: sub-adult females (from weaning to age at first parturition)
-\item \code{FJ}: juvenile females (from birth to weaning)
-\item \code{MA}: adult males (from age at first breeding)
-\item \code{MS}: sub-adult males (from weaning to age at first breeding)
-\item \code{MJ}: juvenile males (from birth to weaning)
 }}
 
 \item{nemain}{Numeric. Energy required for maintenance, defined as the amount of energy needed to keep the animal in equilibrium such that body energy is neither gained nor lost. Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).}

--- a/man/compute_daily_enteric_emissions.Rd
+++ b/man/compute_daily_enteric_emissions.Rd
@@ -6,7 +6,6 @@
 \usage{
 compute_daily_enteric_emissions(
   animal,
-  cohort,
   ym,
   ch4_mitigation_factor,
   diet_ge,
@@ -23,17 +22,6 @@ Supported values include:
 \item \code{BFL}: buffalo
 \item \code{SHP}: sheep
 \item \code{GTS}: goats
-}}
-
-\item{cohort}{Character. Sex- and age-specific cohort code describing the
-production stage of the animals. Supported values include:
-\itemize{
-\item \code{FA}: adult females (from age at first parturition)
-\item \code{FS}: sub-adult females (from weaning to age at first parturition)
-\item \code{FJ}: juvenile females (from birth to weaning)
-\item \code{MA}: adult males (from age at first breeding)
-\item \code{MS}: sub-adult males (from weaning to age at first breeding)
-\item \code{MJ}: juvenile males (from birth to weaning)
 }}
 
 \item{ym}{Numeric. Methane conversion factor (ym), representing the percentage of gross energy of the feed ration that is converted to CH₄ (percentage).}

--- a/tests/testthat/test-directemissions_enteric_core.R
+++ b/tests/testthat/test-directemissions_enteric_core.R
@@ -43,7 +43,6 @@ test_that("compute_daily_enteric_emissions validates inputs and returns expected
   ym <- compute_methane_conversion_factor("CTL", "FA", 0.6)
   ch4 <- compute_daily_enteric_emissions(
     animal = "CTL",
-    cohort = "FA",
     ym = ym,
     ch4_mitigation_factor = 1,
     diet_ge = 18.4,
@@ -54,17 +53,17 @@ test_that("compute_daily_enteric_emissions validates inputs and returns expected
 
   # Chickens: emissions NA
   ym_ch <- compute_methane_conversion_factor("CHK", "FA", 0.7)
-  ch4_ch <- compute_daily_enteric_emissions("CHK", "FA", ym_ch, 1, 16, 0.1)
+  ch4_ch <- compute_daily_enteric_emissions("CHK", ym_ch, 1, 16, 0.1)
   expect_true(is.na(ch4_ch))
 
   # Zero inputs give zero emissions
-  expect_equal(compute_daily_enteric_emissions("CTL", "FA", 0, 1, 18, 10), 0)
-  expect_equal(compute_daily_enteric_emissions("CTL", "FA", 5, 1, 18, 0), 0)
+  expect_equal(compute_daily_enteric_emissions("CTL", 0, 1, 18, 10), 0)
+  expect_equal(compute_daily_enteric_emissions("CTL", 5, 1, 18, 0), 0)
 
   # Invalid arguments
-  expect_error(compute_daily_enteric_emissions("CTL", "FA", -1, 1, 18, 10))  # ym < 0
-  expect_error(compute_daily_enteric_emissions("CTL", "FA", 5, 1, 0, 10))   # diet_ge <= 0
-  expect_error(compute_daily_enteric_emissions("CTL", "FA", 5, 1, 18, -1))  # dmi < 0
+  expect_error(compute_daily_enteric_emissions("CTL", -1, 1, 18, 10))  # ym < 0
+  expect_error(compute_daily_enteric_emissions("CTL", 5, 1, 0, 10))   # diet_ge <= 0
+  expect_error(compute_daily_enteric_emissions("CTL", 5, 1, 18, -1))  # dmi < 0
 
   # Emissions must be non-negative
   expect_gte(ch4, 0)

--- a/tests/testthat/test-energy_requirements_core.R
+++ b/tests/testthat/test-energy_requirements_core.R
@@ -437,7 +437,7 @@ test_that("calc_reg_growth returns NA for non-ruminants", {
 # ---- test calc_total_energy_requirement ----
 test_that("calc_total_energy_requirement returns correct values for cattle", {
   result <- calc_total_energy_requirement(
-    animal = "CTL", cohort = "FA",
+    animal = "CTL",
     nemain = 15.0, neact = 3.0, nelact = 8.0, nework = 0, nepreg = 1.5,
     rem = 0.6, negrow = 0, nefibre = 0, neegg = 0, reg = 0.5, diet_dig = 0.65
   )
@@ -447,7 +447,7 @@ test_that("calc_total_energy_requirement returns correct values for cattle", {
 
 test_that("calc_total_energy_requirement handles sheep with fibre", {
   result <- calc_total_energy_requirement(
-    animal = "SHP", cohort = "FA",
+    animal = "SHP",
     nemain = 8.0, neact = 1.5, nelact = 4.0, nework = 0, nepreg = 1.0,
     rem = 0.55, negrow = 0, nefibre = 0.2, neegg = 0, reg = 0.45, diet_dig = 0.60
   )
@@ -458,7 +458,7 @@ test_that("calc_total_energy_requirement handles sheep with fibre", {
 test_that("calc_total_energy_requirement handles different species", {
   # Test camelids (direct sum)
   result <- calc_total_energy_requirement(
-    animal = "CML", cohort = "FA",
+    animal = "CML",
     nemain = 12.0, neact = 2.0, nelact = 6.0, nework = 1.0, nepreg = 1.5,
     rem = NA, negrow = 0, nefibre = 0.3, neegg = 0, reg = NA, diet_dig = 0.70
   )
@@ -467,7 +467,7 @@ test_that("calc_total_energy_requirement handles different species", {
 
   # Test pigs
   result <- calc_total_energy_requirement(
-    animal = "PGS", cohort = "FA",
+    animal = "PGS", 
     nemain = 10.0, neact = 1.0, nelact = 5.0, nework = 0, nepreg = 2.0,
     rem = NA, negrow = 0, nefibre = 0, neegg = 0, reg = NA, diet_dig = 0.75
   )


### PR DESCRIPTION
`cohort` was removed from the function arguments when not used for the calculations.

Specific functions are:
- `compute_daily_enteric_emissions`
- `calc_total_energy_requirement`