### PR TITLE
[OP#252 & #257] Add cohort-based conditions to nitrogen retention and milk production and fibre production calculations

### DIFF
--- a/R/nitrogen_balance_core_model.R
+++ b/R/nitrogen_balance_core_model.R
@@ -154,7 +154,7 @@ compute_nitrogen_retention <- function(
 
     milk_comp <- if (!is.na(milk_yield) && cohort == "FA" && milk_yield > 0) milk_yield * milk_n else 0
     growth_comp <- if (!is.na(dwg) && dwg > 0) dwg * tissue_n else 0
-    fibre_comp <- if (!is.na(fibre_prod) && fibre_prod > 0) fibre_prod / 365 * fibre_n else 0
+    fibre_comp <- if (!is.na(fibre_prod) &&  cohort %in% c("FA", "FS", "MA", "MS") && fibre_prod > 0) fibre_prod / 365 * fibre_n else 0
 
     return(milk_comp + growth_comp + fibre_comp)
 

--- a/R/nitrogen_balance_core_model.R
+++ b/R/nitrogen_balance_core_model.R
@@ -154,7 +154,7 @@ compute_nitrogen_retention <- function(
 
     milk_comp <- if (!is.na(milk_yield) && cohort == "FA" && milk_yield > 0) milk_yield * milk_n else 0
     growth_comp <- if (!is.na(dwg) && dwg > 0) dwg * tissue_n else 0
-    fibre_comp <- if (!is.na(fibre_prod) &&  cohort %in% c("FA", "FS", "MA", "MS") && fibre_prod > 0) fibre_prod / 365 * fibre_n else 0
+    fibre_comp <- if (!is.na(fibre_prod) &&  cohort %in% c("FA", "FS", "MA", "MS") && animal %in% c("SHP", "GTS", "CML") && fibre_prod > 0) fibre_prod / 365 * fibre_n else 0
 
     return(milk_comp + growth_comp + fibre_comp)
 

--- a/R/production_cohort_core_model.R
+++ b/R/production_cohort_core_model.R
@@ -105,10 +105,20 @@ compute_milk_outputs <- function(
 
 #' Compute Fibre Production
 #'
-#' Computes fibre production for producing cohorts by scaling per-animal
+#' Computes fibre production for producing cohorts (\code{FA}, \code{MA}, \code{FS}, \code{MS})  by scaling per-animal
 #' fibre yield to the assessment period and cohort size.
 #' The output is expressed in kg per cohort per assessment period.
 #' 
+#' @param cohort Character. Sex- and age-specific cohort code describing the
+#'   production stage of the animals. Supported values include:
+#'   \itemize{
+#'     \item \code{FA}: adult females (from age at first parturition)
+#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
+#'     \item \code{FJ}: juvenile females (from birth to weaning)
+#'     \item \code{MA}: adult males (from age at first breeding)
+#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
+#'     \item \code{MJ}: juvenile males (from birth to weaning)
+#'   }
 #' @param fibre_prod Numeric. Annual production yield of fibre, such as wool, cashmere, mohair (kg/head/year).
 #' @param assessment_duration Numeric. Length of the assessment period (days).
 #' @param size Numeric. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts=FJ, FS, FA, MJ, MS, MA)
@@ -120,17 +130,27 @@ compute_milk_outputs <- function(
 #'
 #' @export
 compute_fibre_output <- function(
+    cohort = cohort,
     fibre_prod,
     assessment_duration,
     size
 ) {
   validate_fibre_output_inputs(
+    cohort = cohort,
     fibre_prod = fibre_prod,
     assessment_duration = assessment_duration,
     size = size
   )
   
+  if (cohort %in% c("FA", "FS", "MA", "MS")) {
+    
   fibre_production <- fibre_prod / 365 * assessment_duration * size
+  
+    } else {
+    fibre_production <- 0
+  }
+    
+  
   return(fibre_production)
 }
 

--- a/R/production_cohort_core_model.R
+++ b/R/production_cohort_core_model.R
@@ -1,6 +1,6 @@
 #' Compute Milk Production Outputs
 #'
-#' Computes total milk production for a producing cohort over the assessment
+#' Computes total milk production for a producing cohort (\code{FA}) over the assessment
 #' period and returns multiple production metrics: total milk mass,
 #' milk protein, and fat-protein-corrected milk (FPCM).
 #' All outputs are expressed in kg per cohort per assessment period.
@@ -8,6 +8,16 @@
 #' FPCM is calculated using Equation 10 of the International Dairy Federation
 #' (IDF) Global Carbon Footprint Standard for the Dairy Sector (IDF, 2022).
 #'
+#' @param cohort Character. Sex- and age-specific cohort code describing the
+#'   production stage of the animals. Supported values include:
+#'   \itemize{
+#'     \item \code{FA}: adult females (from age at first parturition)
+#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
+#'     \item \code{FJ}: juvenile females (from birth to weaning)
+#'     \item \code{MA}: adult males (from age at first breeding)
+#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
+#'     \item \code{MJ}: juvenile males (from birth to weaning)
+#'   }
 #' @param milk_yield Numeric.  Average milk yield per milk-producing animal during the assessment duration (kg/head/day).
 #' This value can be calculated by dividing the total milk destinated to human consumption produced per milk-producing animal over the assessment duration by the length of the assessment period.
 #' @param assessment_duration Numeric. Length of the assessment period (days).
@@ -36,6 +46,7 @@
 #' @export
 
 compute_milk_outputs <- function(
+    cohort,
     milk_yield,
     assessment_duration,
     size,
@@ -48,6 +59,7 @@ compute_milk_outputs <- function(
     standard_lactose
 ) {
   validate_milk_outputs_inputs(
+    cohort = cohort,
     milk_yield = milk_yield,
     assessment_duration = assessment_duration,
     size = size,
@@ -59,6 +71,8 @@ compute_milk_outputs <- function(
     standard_fat = standard_fat,
     standard_lactose = standard_lactose
   )
+  
+  if (cohort == "FA"){
 
   # Energy content of standard milk (Mcal/kg) - IDF 2022 formula
   energy_standard <- (0.0929 * standard_fat + 0.0547 * standard_protein + 0.0395 * standard_lactose)
@@ -75,7 +89,13 @@ compute_milk_outputs <- function(
   # FPCM production using energy ratio
   energy_ratio <- energy_milk / energy_standard
   fpcm_production <- energy_ratio * milk_production
-
+  
+  } else {
+  milk_production <- 0
+  milk_protein_production <- 0
+  fpcm_production <- 0
+  }
+    
   return(list(
     output_milk_mass_production = milk_production,
     output_milk_protein_production = milk_protein_production,
@@ -88,7 +108,7 @@ compute_milk_outputs <- function(
 #' Computes fibre production for producing cohorts by scaling per-animal
 #' fibre yield to the assessment period and cohort size.
 #' The output is expressed in kg per cohort per assessment period.
-#'
+#' 
 #' @param fibre_prod Numeric. Annual production yield of fibre, such as wool, cashmere, mohair (kg/head/year).
 #' @param assessment_duration Numeric. Length of the assessment period (days).
 #' @param size Numeric. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts=FJ, FS, FA, MJ, MS, MA)
@@ -109,7 +129,7 @@ compute_fibre_output <- function(
     assessment_duration = assessment_duration,
     size = size
   )
-
+  
   fibre_production <- fibre_prod / 365 * assessment_duration * size
   return(fibre_production)
 }

--- a/R/run_production_cohort.R
+++ b/R/run_production_cohort.R
@@ -129,6 +129,7 @@ run_production_cohort <- function(
   # --- Step 3: Aggregate fibre production ------------------------------------
   # The downstream energy requirements module expects annual fibre tonnage at the cohort level.
   data[ , output_fibre_production := compute_fibre_output(
+    cohort = cohort,
     fibre_prod = fibre_prod,
     assessment_duration = assessment_duration,
     size = size

--- a/R/run_production_cohort.R
+++ b/R/run_production_cohort.R
@@ -110,6 +110,7 @@ run_production_cohort <- function(
   # Standard composition constants reflect IDF 2022 guidance and must remain fixed to
   # reproduce the historical FPCM values distributed with GLEAM.
   data[ , (milk_output_cols) := compute_milk_outputs(
+    cohort = cohort,
     milk_yield = milk_yield,
     assessment_duration = assessment_duration,
     size = size,

--- a/R/validate_production_cohort_core_model.R
+++ b/R/validate_production_cohort_core_model.R
@@ -68,10 +68,14 @@ validate_milk_outputs_inputs <- function(
 #'
 #' @noRd
 validate_fibre_output_inputs <- function(
+    cohort,
     fibre_prod,
     assessment_duration,
     size
 ) {
+  
+  validate_cohort_code(cohort)
+  
   # Scalar numeric inputs
   validate_scalar_numeric(fibre_prod, "fibre_prod")
   validate_scalar_numeric(assessment_duration, "assessment_duration")

--- a/R/validate_production_cohort_core_model.R
+++ b/R/validate_production_cohort_core_model.R
@@ -2,6 +2,7 @@
 #'
 #' @noRd
 validate_milk_outputs_inputs <- function(
+    cohort,
     milk_yield,
     assessment_duration,
     size,
@@ -13,6 +14,9 @@ validate_milk_outputs_inputs <- function(
     standard_fat,
     standard_lactose
 ) {
+  
+  validate_cohort_code(cohort)
+  
   # Scalar numeric inputs
   validate_scalar_numeric(milk_yield, "milk_yield")
   validate_scalar_numeric(assessment_duration, "assessment_duration")

--- a/man/compute_fibre_output.Rd
+++ b/man/compute_fibre_output.Rd
@@ -4,9 +4,20 @@
 \alias{compute_fibre_output}
 \title{Compute Fibre Production}
 \usage{
-compute_fibre_output(fibre_prod, assessment_duration, size)
+compute_fibre_output(cohort = cohort, fibre_prod, assessment_duration, size)
 }
 \arguments{
+\item{cohort}{Character. Sex- and age-specific cohort code describing the
+production stage of the animals. Supported values include:
+\itemize{
+\item \code{FA}: adult females (from age at first parturition)
+\item \code{FS}: sub-adult females (from weaning to age at first parturition)
+\item \code{FJ}: juvenile females (from birth to weaning)
+\item \code{MA}: adult males (from age at first breeding)
+\item \code{MS}: sub-adult males (from weaning to age at first breeding)
+\item \code{MJ}: juvenile males (from birth to weaning)
+}}
+
 \item{fibre_prod}{Numeric. Annual production yield of fibre, such as wool, cashmere, mohair (kg/head/year).}
 
 \item{assessment_duration}{Numeric. Length of the assessment period (days).}
@@ -20,7 +31,7 @@ Cohorts that do not produce fibre should return zero output through
 upstream parameterisation.
 }
 \description{
-Computes fibre production for producing cohorts by scaling per-animal
+Computes fibre production for producing cohorts (\code{FA}, \code{MA}, \code{FS}, \code{MS})  by scaling per-animal
 fibre yield to the assessment period and cohort size.
 The output is expressed in kg per cohort per assessment period.
 }

--- a/man/compute_milk_outputs.Rd
+++ b/man/compute_milk_outputs.Rd
@@ -5,6 +5,7 @@
 \title{Compute Milk Production Outputs}
 \usage{
 compute_milk_outputs(
+  cohort,
   milk_yield,
   assessment_duration,
   size,
@@ -18,6 +19,17 @@ compute_milk_outputs(
 )
 }
 \arguments{
+\item{cohort}{Character. Sex- and age-specific cohort code describing the
+production stage of the animals. Supported values include:
+\itemize{
+\item \code{FA}: adult females (from age at first parturition)
+\item \code{FS}: sub-adult females (from weaning to age at first parturition)
+\item \code{FJ}: juvenile females (from birth to weaning)
+\item \code{MA}: adult males (from age at first breeding)
+\item \code{MS}: sub-adult males (from weaning to age at first breeding)
+\item \code{MJ}: juvenile males (from birth to weaning)
+}}
+
 \item{milk_yield}{Numeric.  Average milk yield per milk-producing animal during the assessment duration (kg/head/day).
 This value can be calculated by dividing the total milk destinated to human consumption produced per milk-producing animal over the assessment duration by the length of the assessment period.}
 
@@ -49,7 +61,7 @@ Non-zero milk outputs are only expected for adult female cohorts. All other
 cohorts should return zero milk production through upstream parameterisation.
 }
 \description{
-Computes total milk production for a producing cohort over the assessment
+Computes total milk production for a producing cohort (\code{FA}) over the assessment
 period and returns multiple production metrics: total milk mass,
 milk protein, and fat-protein-corrected milk (FPCM).
 All outputs are expressed in kg per cohort per assessment period.

--- a/tests/testthat/test-production_cohort_core.R
+++ b/tests/testthat/test-production_cohort_core.R
@@ -1,6 +1,7 @@
 # ---- test compute_milk_outputs ----
 test_that("compute_milk_outputs returns expected output structure", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 10,
     assessment_duration = 365,
     size = 100,
@@ -23,6 +24,7 @@ test_that("compute_milk_outputs returns expected output structure", {
 
 test_that("compute_milk_outputs calculates milk mass production correctly", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 20,
     assessment_duration = 365,
     size = 50,
@@ -41,6 +43,7 @@ test_that("compute_milk_outputs calculates milk mass production correctly", {
 
 test_that("compute_milk_outputs calculates milk protein production correctly", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 15,
     assessment_duration = 365,
     size = 80,
@@ -60,6 +63,7 @@ test_that("compute_milk_outputs calculates milk protein production correctly", {
 
 test_that("compute_milk_outputs calculates FPCM using energy ratio", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 12,
     assessment_duration = 365,
     size = 60,
@@ -79,6 +83,7 @@ test_that("compute_milk_outputs calculates FPCM using energy ratio", {
 
 test_that("compute_milk_outputs calculates FPCM correctly with different composition", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 12,
     assessment_duration = 365,
     size = 60,
@@ -104,6 +109,7 @@ test_that("compute_milk_outputs calculates FPCM correctly with different composi
 test_that("compute_milk_outputs handles higher fat content correctly", {
   # Higher fat should result in higher FPCM (energy ratio > 1)
   standard_result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 10,
     assessment_duration = 365,
     size = 100,
@@ -117,6 +123,7 @@ test_that("compute_milk_outputs handles higher fat content correctly", {
   )
 
   high_fat_result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 10,
     assessment_duration = 365,
     size = 100,
@@ -134,6 +141,7 @@ test_that("compute_milk_outputs handles higher fat content correctly", {
 
 test_that("compute_milk_outputs handles zero size", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 10,
     assessment_duration = 365,
     size = 0,
@@ -153,6 +161,7 @@ test_that("compute_milk_outputs handles zero size", {
 
 test_that("compute_milk_outputs handles zero milking fraction", {
   result <- compute_milk_outputs(
+    cohort = "FA",
     milk_yield = 10,
     assessment_duration = 365,
     size = 100,
@@ -173,6 +182,7 @@ test_that("compute_milk_outputs handles zero milking fraction", {
 test_that("compute_milk_outputs handles validation errors", {
   expect_error(
     compute_milk_outputs(
+      cohort = "FA",
       milk_yield = -10, assessment_duration = 365, size = 100,
       milking_fraction = 0.8, milk_protein = 0.033, milk_fat = 0.04,
       lactose = 0.048, standard_protein = 0.033, standard_fat = 0.04,
@@ -183,6 +193,7 @@ test_that("compute_milk_outputs handles validation errors", {
 
   expect_error(
     compute_milk_outputs(
+      cohort = "FA",
       milk_yield = 10, assessment_duration = 365, size = 100,
       milking_fraction = 1.5, milk_protein = 0.033, milk_fat = 0.04,
       lactose = 0.048, standard_protein = 0.033, standard_fat = 0.04,
@@ -193,6 +204,7 @@ test_that("compute_milk_outputs handles validation errors", {
 
   expect_error(
     compute_milk_outputs(
+      cohort = "FA",
       milk_yield = 10, assessment_duration = 365, size = 100,
       milking_fraction = 0.8, milk_protein = 0.033, milk_fat = 1.5,
       lactose = 0.048, standard_protein = 0.033, standard_fat = 0.04,

--- a/tests/testthat/test-production_cohort_core.R
+++ b/tests/testthat/test-production_cohort_core.R
@@ -218,6 +218,7 @@ test_that("compute_milk_outputs handles validation errors", {
 # ---- test compute_fibre_output ----
 test_that("compute_fibre_output returns expected value", {
   result <- compute_fibre_output(
+    cohort = "FS",
     fibre_prod = 0.1,
     assessment_duration = 365,
     size = 100
@@ -229,6 +230,7 @@ test_that("compute_fibre_output returns expected value", {
 
 test_that("compute_fibre_output handles zero fibre yield", {
   result <- compute_fibre_output(
+    cohort = "FS",
     fibre_prod = 0,
     assessment_duration = 365,
     size = 100
@@ -239,6 +241,7 @@ test_that("compute_fibre_output handles zero fibre yield", {
 
 test_that("compute_fibre_output handles zero size", {
   result <- compute_fibre_output(
+    cohort = "FA",
     fibre_prod = 0.1,
     assessment_duration = 365,
     size = 0
@@ -249,12 +252,14 @@ test_that("compute_fibre_output handles zero size", {
 
 test_that("compute_fibre_output handles different assessment durations", {
   result_365 <- compute_fibre_output(
+    cohort = "MA",
     fibre_prod = 0.1,
     assessment_duration = 365,
     size = 100
   )
 
   result_180 <- compute_fibre_output(
+    cohort = "MA",
     fibre_prod = 0.1,
     assessment_duration = 180,
     size = 100
@@ -265,6 +270,7 @@ test_that("compute_fibre_output handles different assessment durations", {
 
 test_that("compute_fibre_output handles large values", {
   result <- compute_fibre_output(
+    cohort = "MS",
     fibre_prod = 5.0,
     assessment_duration = 365,
     size = 1000
@@ -276,17 +282,17 @@ test_that("compute_fibre_output handles large values", {
 
 test_that("compute_fibre_output handles validation errors", {
   expect_error(
-    compute_fibre_output(fibre_prod = -0.1, assessment_duration = 365, size = 100),
+    compute_fibre_output(cohort = "MA", fibre_prod = -0.1, assessment_duration = 365, size = 100),
     "fibre_prod"
   )
 
   expect_error(
-    compute_fibre_output(fibre_prod = 0.1, assessment_duration = 0, size = 100),
+    compute_fibre_output(cohort = "MA", fibre_prod = 0.1, assessment_duration = 0, size = 100),
     "assessment_duration"
   )
 
   expect_error(
-    compute_fibre_output(fibre_prod = 0.1, assessment_duration = 365, size = -100),
+    compute_fibre_output(cohort = "MA", fibre_prod = 0.1, assessment_duration = 365, size = -100),
     "size"
   )
 })


### PR DESCRIPTION
**Summary**

This pull request introduces explicit cohort-based logic in the nitrogen balance and production modules to ensure that calculations are only performed for biologically relevant animal groups, consistent with the assumptions used in the energy requirements module.
This creates also the basis for a 'safe' separation of herd and cohort-level parameters.

**Changes included**

- Nitrogen balance module - `compute_nitrogen_retention`
  - Added a cohort condition to calculate fibre_comp only for the following cohorts: `FA, FS, MA, MS`
  - All other cohorts now return 0 for this component.

- Production module
  - `compute_milk_outputs` function
    - Updated logic so that milk outputs are only calculated for cohort `FA`.
    - All other cohorts now explicitly return 0 for: milk mass production, milk protein production, FPCM production
  -  `compute_fibre_outputs ` function
      - Update logic so that fibre outputs are only calculated for `FA, FS, MA, MS`
     -   All other cohorts now return 0 for this component.