### PR TITLE
[OP#261] Correction of calc_energy_allocation_fibre and calc_energy_allocation_work

### DIFF
--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -416,6 +416,8 @@ calc_energy_allocation_fibre <- function(
 #'     \item \code{SHP}: sheep
 #'     \item \code{GTS}: goats
 #'   }
+#'   
+#' @param size Numeric. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts=FJ, FS, FA, MJ, MS, MA)
 #' @param work_energy_requirement Numeric. Energy required for work, used to estimate the energy required for draught power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).
 #' @param ratio_ne_to_me Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.
 #' @param assessment_duration Numeric. Length of the assessment period (days).
@@ -472,20 +474,21 @@ calc_energy_allocation_fibre <- function(
 #' @export
 calc_energy_allocation_work <- function(
     animal,
+    size,
     work_energy_requirement,
     ratio_ne_to_me,
     assessment_duration
 ) {
   validate_allocation_work_inputs(
-    animal, work_energy_requirement, ratio_ne_to_me, assessment_duration
+    animal, size, work_energy_requirement, ratio_ne_to_me, assessment_duration
   )
 
   if (animal == "CML") {
     # Camelids: convert ME to NE using ratio
-    energy_allocation_work <- work_energy_requirement * ratio_ne_to_me * assessment_duration
+    energy_allocation_work <- work_energy_requirement * ratio_ne_to_me * assessment_duration * size
   } else {
     # Other species: direct calculation
-    energy_allocation_work <- work_energy_requirement * assessment_duration
+    energy_allocation_work <- work_energy_requirement * assessment_duration * size
   }
 
   return(energy_allocation_work)

--- a/R/allocation_core_model.R
+++ b/R/allocation_core_model.R
@@ -308,7 +308,8 @@ calc_energy_allocation_meat <- function(
 #'     \item \code{SHP}: sheep
 #'     \item \code{GTS}: goats
 #'   }
-#'
+#' @param size Numeric. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts=FJ, FS, FA, MJ, MS, MA)
+
 #' @param fibre_energy_requirement Numeric. Energy required for the synthesis of fibre for SHP, GTS and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for SHP and GTS and as metabolizable energy for CML (MJ/head/day).
 #' @param ratio_ne_to_me Numeric. Ratio of metabolizable energy converted to net energy (fraction). Used for CML.
 #' @param assessment_duration Numeric. Length of the assessment period (days).
@@ -369,20 +370,21 @@ calc_energy_allocation_meat <- function(
 #' @export
 calc_energy_allocation_fibre <- function(
     animal,
+    size,
     fibre_energy_requirement,
     ratio_ne_to_me,
     assessment_duration
 ) {
   validate_allocation_fibre_inputs(
-    animal, fibre_energy_requirement, ratio_ne_to_me, assessment_duration
+    animal, size, fibre_energy_requirement, ratio_ne_to_me, assessment_duration
   )
 
   if (animal %in% c("GTS", "SHP")) {
     # Sheep and goats: direct NE calculation
-    energy_allocation_fibre <- fibre_energy_requirement * assessment_duration
+    energy_allocation_fibre <- fibre_energy_requirement * assessment_duration * size
   } else if (animal == "CML") {
     # Camelids: convert ME to NE using ratio
-    energy_allocation_fibre <- fibre_energy_requirement * ratio_ne_to_me * assessment_duration
+    energy_allocation_fibre <- fibre_energy_requirement * ratio_ne_to_me * assessment_duration * size
   } else {
     # Other species: no fibre production
     energy_allocation_fibre <- 0

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -99,6 +99,7 @@ run_allocation <- function(
   # Fibre energy allocation: applies camelid conversion factor when needed
   allocation_inputs[, energy_allocation_fibre := calc_energy_allocation_fibre(
     animal = Animal_short,
+    size = size,
     fibre_energy_requirement = nefibre,
     ratio_ne_to_me = ratio_ne_me_camelids,
     assessment_duration = assessment_duration

--- a/R/run_allocation.R
+++ b/R/run_allocation.R
@@ -108,6 +108,7 @@ run_allocation <- function(
   # Work energy allocation: applies camelid conversion factor when needed
   allocation_inputs[, energy_allocation_work := calc_energy_allocation_work(
     animal = Animal_short,
+    size = size,
     work_energy_requirement = nework,
     ratio_ne_to_me = ratio_ne_me_camelids,
     assessment_duration = assessment_duration

--- a/R/validate_allocation_core_model.R
+++ b/R/validate_allocation_core_model.R
@@ -139,6 +139,7 @@ validate_allocation_meat_inputs <- function(
 #' @noRd
 validate_allocation_fibre_inputs <- function(
     animal,
+    size,
     fibre_energy_requirement,
     ratio_ne_to_me,
     assessment_duration
@@ -147,6 +148,7 @@ validate_allocation_fibre_inputs <- function(
   validate_scalar_numeric(fibre_energy_requirement, "fibre_energy_requirement")
   validate_scalar_numeric(ratio_ne_to_me, "ratio_ne_to_me")
   validate_scalar_numeric(assessment_duration, "assessment_duration")
+  validate_scalar_numeric(size, "size")
 
   # Validate animal species
   # Note: Allocation module uses these specific species codes
@@ -167,6 +169,9 @@ validate_allocation_fibre_inputs <- function(
   if (assessment_duration <= 0 || assessment_duration > 3650) {
     cli::cli_abort("{.arg assessment_duration} must be between 0 and 3650 days.")
   }
+  if (size < 0) {
+  cli::cli_abort("{.arg size} must be non-negative.")
+    }
 }
 
 #' Validate inputs for calc_energy_allocation_work

--- a/R/validate_allocation_core_model.R
+++ b/R/validate_allocation_core_model.R
@@ -200,6 +200,7 @@ validate_allocation_fibre_inputs <- function(
 #' @noRd
 validate_allocation_work_inputs <- function(
     animal,
+    size,
     work_energy_requirement,
     ratio_ne_to_me,
     assessment_duration
@@ -208,6 +209,7 @@ validate_allocation_work_inputs <- function(
   validate_scalar_numeric(work_energy_requirement, "work_energy_requirement")
   validate_scalar_numeric(ratio_ne_to_me, "ratio_ne_to_me")
   validate_scalar_numeric(assessment_duration, "assessment_duration")
+  validate_scalar_numeric(size, "size")
 
   # Validate animal species
   # Note: Allocation module uses these specific species codes
@@ -227,5 +229,8 @@ validate_allocation_work_inputs <- function(
   }
   if (assessment_duration <= 0 || assessment_duration > 3650) {
     cli::cli_abort("{.arg assessment_duration} must be between 0 and 3650 days.")
+  }
+  if (size < 0) {
+    cli::cli_abort("{.arg size} must be non-negative.")
   }
 }

--- a/man/calc_energy_allocation_fibre.Rd
+++ b/man/calc_energy_allocation_fibre.Rd
@@ -6,6 +6,7 @@
 \usage{
 calc_energy_allocation_fibre(
   animal,
+  size,
   fibre_energy_requirement,
   ratio_ne_to_me,
   assessment_duration
@@ -22,6 +23,8 @@ Supported values include:
 \item \code{SHP}: sheep
 \item \code{GTS}: goats
 }}
+
+\item{size}{Numeric. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts=FJ, FS, FA, MJ, MS, MA)}
 
 \item{fibre_energy_requirement}{Numeric. Energy required for the synthesis of fibre for SHP, GTS and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for SHP and GTS and as metabolizable energy for CML (MJ/head/day).}
 

--- a/man/calc_energy_allocation_work.Rd
+++ b/man/calc_energy_allocation_work.Rd
@@ -6,6 +6,7 @@
 \usage{
 calc_energy_allocation_work(
   animal,
+  size,
   work_energy_requirement,
   ratio_ne_to_me,
   assessment_duration
@@ -22,6 +23,8 @@ Supported values include:
 \item \code{SHP}: sheep
 \item \code{GTS}: goats
 }}
+
+\item{size}{Numeric. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts=FJ, FS, FA, MJ, MS, MA)}
 
 \item{work_energy_requirement}{Numeric. Energy required for work, used to estimate the energy required for draught power for CTL, BFL and CML. Assumed to be 0 for other species. (MJ/head/day). Expressed as net energy for CTL, BFL, SHP, GTS and as metabolizable energy for CML and PGS (MJ/head/day).}
 

--- a/tests/testthat/test-allocation_core.R
+++ b/tests/testthat/test-allocation_core.R
@@ -223,6 +223,7 @@ test_that("calc_energy_allocation_meat validates weight bounds", {
 test_that("calc_energy_allocation_fibre returns correct value for sheep", {
   result <- calc_energy_allocation_fibre(
     animal = "SHP",
+    size = 100,
     fibre_energy_requirement = 5,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -230,23 +231,25 @@ test_that("calc_energy_allocation_fibre returns correct value for sheep", {
 
   expect_type(result, "double")
   expect_length(result, 1)
-  expect_equal(result, 5 * 365)  # Direct calculation for sheep
+  expect_equal(result, 5 * 365 * 100)  # Direct calculation for sheep
 })
 
 test_that("calc_energy_allocation_fibre returns correct value for goats", {
   result <- calc_energy_allocation_fibre(
     animal = "GTS",
+    size = 100,
     fibre_energy_requirement = 4,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
   )
 
-  expect_equal(result, 4 * 365)  # Direct calculation for goats
+  expect_equal(result, 4 * 365 * 100)  # Direct calculation for goats
 })
 
 test_that("calc_energy_allocation_fibre returns correct value for camelids", {
   result <- calc_energy_allocation_fibre(
     animal = "CML",
+    size = 100,
     fibre_energy_requirement = 6,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -254,12 +257,13 @@ test_that("calc_energy_allocation_fibre returns correct value for camelids", {
 
   expect_type(result, "double")
   # For camelids: fibre_energy * ratio_ne_to_me * assessment_duration
-  expect_equal(result, 6 * 0.43 * 365)
+  expect_equal(result, 6 * 0.43 * 365 * 100)
 })
 
 test_that("calc_energy_allocation_fibre returns zero for non-fibre species", {
   result_cattle <- calc_energy_allocation_fibre(
     animal = "CTL",
+    size = 100,
     fibre_energy_requirement = 10,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -268,6 +272,7 @@ test_that("calc_energy_allocation_fibre returns zero for non-fibre species", {
 
   result_pigs <- calc_energy_allocation_fibre(
     animal = "PGS",
+    size = 100,
     fibre_energy_requirement = 10,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -278,25 +283,26 @@ test_that("calc_energy_allocation_fibre returns zero for non-fibre species", {
 test_that("calc_energy_allocation_fibre uses default assessment_duration", {
   result <- calc_energy_allocation_fibre(
     animal = "SHP",
+    size = 100,
     fibre_energy_requirement = 5,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
   )
 
-  expect_equal(result, 5 * 365)  # Default is 365 days
+  expect_equal(result, 5 * 365 * 100)  # Default is 365 days
 })
 
 test_that("calc_energy_allocation_fibre validates inputs", {
   expect_error(
-    calc_energy_allocation_fibre(animal = "INVALID", fibre_energy_requirement = 5, ratio_ne_to_me = 0.43, assessment_duration = 365),
+    calc_energy_allocation_fibre(animal = "INVALID", size = 100, fibre_energy_requirement = 5, ratio_ne_to_me = 0.43, assessment_duration = 365),
     "must be one of"
   )
   expect_error(
-    calc_energy_allocation_fibre(animal = "SHP", fibre_energy_requirement = -5, ratio_ne_to_me = 0.43, assessment_duration = 365),
+    calc_energy_allocation_fibre(animal = "SHP", size = 100, fibre_energy_requirement = -5, ratio_ne_to_me = 0.43, assessment_duration = 365),
     "must be non-negative"
   )
   expect_error(
-    calc_energy_allocation_fibre(animal = "SHP", fibre_energy_requirement = 5, ratio_ne_to_me = 1.5, assessment_duration = 365),
+    calc_energy_allocation_fibre(animal = "SHP", size = 100, fibre_energy_requirement = 5, ratio_ne_to_me = 1.5, assessment_duration = 365),
     "must be between 0 and 1"
   )
 })

--- a/tests/testthat/test-allocation_core.R
+++ b/tests/testthat/test-allocation_core.R
@@ -312,6 +312,7 @@ test_that("calc_energy_allocation_fibre validates inputs", {
 test_that("calc_energy_allocation_work returns correct value for camelids", {
   result <- calc_energy_allocation_work(
     animal = "CML",
+    size = 100, 
     work_energy_requirement = 10,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -320,12 +321,13 @@ test_that("calc_energy_allocation_work returns correct value for camelids", {
   expect_type(result, "double")
   expect_length(result, 1)
   # For camelids: work_energy * ratio_ne_to_me * assessment_duration
-  expect_equal(result, 10 * 0.43 * 365)
+  expect_equal(result, 10 * 0.43 * 365 * 100)
 })
 
 test_that("calc_energy_allocation_work returns correct value for non-camelids", {
   result <- calc_energy_allocation_work(
     animal = "CTL",
+    size = 100, 
     work_energy_requirement = 8,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -333,23 +335,25 @@ test_that("calc_energy_allocation_work returns correct value for non-camelids", 
 
   expect_type(result, "double")
   # For non-camelids: work_energy * assessment_duration (ratio not applied)
-  expect_equal(result, 8 * 365)
+  expect_equal(result, 8 * 365 * 100)
 })
 
 test_that("calc_energy_allocation_work uses default assessment_duration", {
   result <- calc_energy_allocation_work(
     animal = "CTL",
+    size = 100, 
     work_energy_requirement = 8,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
   )
 
-  expect_equal(result, 8 * 365)  # Default is 365 days
+  expect_equal(result, 8 * 365 * 100)  # Default is 365 days
 })
 
 test_that("calc_energy_allocation_work handles zero energy requirement", {
   result <- calc_energy_allocation_work(
     animal = "CTL",
+    size = 100, 
     work_energy_requirement = 0,
     ratio_ne_to_me = 0.43,
     assessment_duration = 365
@@ -360,19 +364,19 @@ test_that("calc_energy_allocation_work handles zero energy requirement", {
 
 test_that("calc_energy_allocation_work validates inputs", {
   expect_error(
-    calc_energy_allocation_work(animal = "INVALID", work_energy_requirement = 10, ratio_ne_to_me = 0.43, assessment_duration = 365),
+    calc_energy_allocation_work(animal = "INVALID", size = 100, work_energy_requirement = 10, ratio_ne_to_me = 0.43, assessment_duration = 365),
     "must be one of"
   )
   expect_error(
-    calc_energy_allocation_work(animal = "CML", work_energy_requirement = -5, ratio_ne_to_me = 0.43, assessment_duration = 365),
+    calc_energy_allocation_work(animal = "CML", size = 100, work_energy_requirement = -5, ratio_ne_to_me = 0.43, assessment_duration = 365),
     "must be non-negative"
   )
   expect_error(
-    calc_energy_allocation_work(animal = "CML", work_energy_requirement = 10, ratio_ne_to_me = -0.1, assessment_duration = 365),
+    calc_energy_allocation_work(animal = "CML", size = 100, work_energy_requirement = 10, ratio_ne_to_me = -0.1, assessment_duration = 365),
     "must be between 0 and 1"
   )
   expect_error(
-    calc_energy_allocation_work(animal = "CML", work_energy_requirement = 10, ratio_ne_to_me = 0.43, assessment_duration = 5000),
+    calc_energy_allocation_work(animal = "CML", size = 100, work_energy_requirement = 10, ratio_ne_to_me = 0.43, assessment_duration = 5000),
     "must be between 0 and 3650"
   )
 })


### PR DESCRIPTION
This pull request corrects the scaling logic in `calc_energy_allocation_fibre` and `calc_energy_allocation_work` by explicitly multiplying by cohort `size`, ensuring that fibre energy allocation and work outputs are expressed in kg per cohort per assessment period rather than per-head values (see commit)