### PR TITLE
[OP#266] Refactor calc_volatile_solids to remove hard-coded ash and UE assumptions

### DIFF
--- a/R/directemissions_manure_core_model.R
+++ b/R/directemissions_manure_core_model.R
@@ -19,7 +19,7 @@
 #' @param diet_dig Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)
 #' @param diet_me Numeric. Average metabolizable energy content of the diet (MJ/kg DM).
 #' @param diet_ge Numeric. Average gross energy content of the diet (MJ/kg DM).
-#'
+#' 
 #' @return Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).
 #' 
 #' @details
@@ -39,7 +39,7 @@
 #'   \item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
 #'     \code{vs = dmi * (1.04 - diet_dig) * 0.92}.
 #'     The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
-#'     of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi. 
+#' of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi. 
 #'     Second, it is assumed that Urinary energy is 4% and the Ash content in feed is 8%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
 #'     }
 #'   \item \strong{Swine} (\code{"PGS"}):
@@ -57,19 +57,10 @@
 #' IPCC. (2006). \emph{2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from
 #' Livestock and Manure Management. Equation 10.24.
 #' @export
-calc_volatile_solids <- function(animal, dmi, diet_dig, diet_me, diet_ge) {
-  validate_manure_inputs(animal, dmi, diet_dig, diet_me, diet_ge)
-
-  # Row-by-row calculation (scalar values)
-  if (animal %in% c("CTL", "BFL", "CML", "SHP", "GTS")) {
-    # Case 1: CTL, BFL, CML, SHP, GTS
-    vs <- dmi * (1.04 - diet_dig) * 0.92
-  } else if (animal == "PGS") {
-    # Case 2: PGS (2019)
-    vs <- dmi * (1.02 - diet_dig) * 0.94
-  } else {
-    vs <- 0
-  }
+calc_volatile_solids <- function(dmi, diet_dig, urinary_energy_fraction, diet_ash) {
+  validate_manure_inputs(dmi, diet_dig, urinary_energy_fraction, diet_ash)
+  
+  vs <- dmi * (1 - diet_dig + urinary_energy_fraction) * (1 - diet_ash)
 
   return(vs)
 }

--- a/R/directemissions_manure_core_model.R
+++ b/R/directemissions_manure_core_model.R
@@ -5,20 +5,10 @@
 #' and is required to proceed with the estimate of methane emissions from manure maanagement.
 #'
 #'
-#' @param animal Character. Code identifying the livestock species.
-#'   Supported values include:
-#'   \itemize{
-#'     \item \code{PGS}: pigs
-#'     \item \code{CML}: camels
-#'     \item \code{CTL}: cattle
-#'     \item \code{BFL}: buffalo
-#'     \item \code{SHP}: sheep
-#'     \item \code{GTS}: goats
-#'   }
 #' @param dmi Numeric. Daily dry matter intake of feed (kg DM/head/day).
 #' @param diet_dig Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)
-#' @param diet_me Numeric. Average metabolizable energy content of the diet (MJ/kg DM).
-#' @param diet_ge Numeric. Average gross energy content of the diet (MJ/kg DM).
+#' @param urinary_energy_fraction Numeric. Average ash content of feed, calculated as a fraction of the dry matter intake (kg ash/kg DM)
+#' @param diet_ash Numeric. Fraction of animal's gross energy that is excreted in urine (fraction).
 #' 
 #' @return Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).
 #' 
@@ -31,23 +21,10 @@
 #'
 #' **Implementation note (simplified coefficients).**
 #' This package uses simplified algebraic forms by species/method that are consistent with the
-#' structure of Eq. 10.24 under fixed/default assumptions for \eqn{UE} and \eqn{ASH}, and with
-#' digestibility supplied directly as a fraction (\code{diet_dig}). 
-#' 
-#' **Species/method branches**
-#' \itemize{
-#'   \item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
-#'     \code{vs = dmi * (1.04 - diet_dig) * 0.92}.
-#'     The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
+#' structure of Eq. 10.24. 
+#' Specifically, in IPCC guidelines the the average gross energy content of the ration is used instead 
 #' of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi. 
-#'     Second, it is assumed that Urinary energy is 4% and the Ash content in feed is 8%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
-#'     }
-#'   \item \strong{Swine} (\code{"PGS"}):
-#'     \itemize{
-#'       \item \code{vs = dmi * (1.02 - diet_dig) * 0.94}.
-#'       It is assumed that urinary energy is 2% and the ash content in feed is 6% (based on IPCC, 2019). Therefore, GE × (GE + UE) becomes 1.02 and 1 – ASH becomes 0.94.
-#'     }
-#' }
+#'     
 #'
 #'
 #'@references

--- a/R/run_directemissions_manure.R
+++ b/R/run_directemissions_manure.R
@@ -13,6 +13,31 @@
 #' @param ipcc_method Character. IPCC method to use: "2006" or "2019". Defaults to "2019".
 #'
 #' @return A data.table with added emission columns
+#' 
+#' @details
+#' 
+#' # TEMPORARY / This will have to be revised and incorporated with the full updated documentation. 
+#' #' **Implementation note (simplified coefficients).**
+#' This package uses simplified algebraic forms by species/method that are consistent with the
+#' structure of Eq. 10.24 under fixed/default assumptions for \eqn{UE} and \eqn{ASH}, and with
+#' digestibility supplied directly as a fraction (\code{diet_dig}). 
+#' 
+#' **Species/method branches**
+#' \itemize{
+#'   \item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
+#'     \code{vs = dmi * (1.04 - diet_dig) * 0.92}.
+#'     The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
+#'     of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi. 
+#'     Second, it is assumed that Urinary energy is 4% and the Ash content in feed is 8%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
+#'     }
+#'   \item \strong{Swine} (\code{"PGS"}):
+#'     \itemize{
+#'       \item \code{vs = dmi * (1.02 - diet_dig) * 0.94}.
+#'       It is assumed that urinary energy is 2% and the ash content in feed is 6% (based on IPCC, 2019). Therefore, GE × (GE + UE) becomes 1.02 and 1 – ASH becomes 0.94.
+#'     }
+#' }
+#'
+#' 
 #'
 #' @examples
 #' \dontrun{

--- a/R/run_directemissions_manure.R
+++ b/R/run_directemissions_manure.R
@@ -105,11 +105,12 @@ run_directemissions_manure <- function(gleam_data, ipcc_method = "2019") {
   #### VS - IPCC method------
   gleam_data[, paste0("vs", ipcc_method) :=
                calc_volatile_solids(
-                 animal = Animal_short,
                  dmi = dmi,
                  diet_dig = diet_dig,
-                 diet_me = diet_me,
-                 diet_ge = diet_ge
+                 urinary_energy_fraction =
+                   fifelse(Animal_short == "PGS", 0.02, 0.04),
+                 diet_ash =
+                   fifelse(Animal_short == "PGS", 0.06, 0.08)
                ),
              by = .I
   ]

--- a/R/validate_directemissions_manure_core_model.R
+++ b/R/validate_directemissions_manure_core_model.R
@@ -1,25 +1,13 @@
 #' Validate inputs for calc_volatile_solids
 #'
 #' @noRd
-validate_manure_inputs <- function(animal_short, dmi, diet_dig, diet_me, diet_ge) {
-  # Character inputs
-  if (!is.character(animal_short) || length(animal_short) == 0 || anyNA(animal_short)) {
-    cli::cli_abort("{.arg animal_short} must be a non-empty character vector.")
-  }
-
-  # Validate animal species
-  valid_animals <- c("CTL", "BFL", "CML", "SHP", "GTS", "PGS", "CHK")
-  if (!all(animal_short %in% valid_animals)) {
-    cli::cli_abort(
-      "{.arg animal_short} must contain only values from: {cli::format_inline('{valid_animals}')}"
-    )
-  }
-
+validate_manure_inputs <- function(dmi, diet_dig, urinary_energy_fraction, diet_ash) 
+{
   # Numeric inputs
   validate_scalar_numeric(dmi, "dmi")
   validate_scalar_numeric(diet_dig, "diet_dig")
-  validate_scalar_numeric(diet_me, "diet_me")
-  validate_scalar_numeric(diet_ge, "diet_ge")
+  validate_scalar_numeric(urinary_energy_fraction, "urinary_energy_fraction")
+  validate_scalar_numeric(diet_ash, "diet_ash")
 
   # Basic range checks
   if (any(dmi < 0)) {
@@ -28,11 +16,11 @@ validate_manure_inputs <- function(animal_short, dmi, diet_dig, diet_me, diet_ge
   if (any(diet_dig < 0 | diet_dig > 1)) {
     cli::cli_abort("{.arg diet_dig} must be between 0 and 1.")
   }
-  if (any(diet_me < 0)) {
-    cli::cli_abort("{.arg diet_me} must be non-negative.")
+  if (any(urinary_energy_fraction < 0)) {
+    cli::cli_abort("{.arg urinary_energy_fraction} must be non-negative.")
   }
-  if (any(diet_ge <= 0)) {
-    cli::cli_abort("{.arg diet_ge} must be strictly positive.")
+  if (any(diet_ash <= 0)) {
+    cli::cli_abort("{.arg diet_ash} must be strictly positive.")
   }
 }
 

--- a/man/calc_volatile_solids.Rd
+++ b/man/calc_volatile_solids.Rd
@@ -4,27 +4,16 @@
 \alias{calc_volatile_solids}
 \title{Calculate Volatile Solids for Manure Emissions}
 \usage{
-calc_volatile_solids(animal, dmi, diet_dig, diet_me, diet_ge)
+calc_volatile_solids(dmi, diet_dig, urinary_energy_fraction, diet_ash)
 }
 \arguments{
-\item{animal}{Character. Code identifying the livestock species.
-Supported values include:
-\itemize{
-\item \code{PGS}: pigs
-\item \code{CML}: camels
-\item \code{CTL}: cattle
-\item \code{BFL}: buffalo
-\item \code{SHP}: sheep
-\item \code{GTS}: goats
-}}
-
 \item{dmi}{Numeric. Daily dry matter intake of feed (kg DM/head/day).}
 
 \item{diet_dig}{Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction)}
 
-\item{diet_me}{Numeric. Average metabolizable energy content of the diet (MJ/kg DM).}
+\item{urinary_energy_fraction}{Numeric. Average ash content of feed, calculated as a fraction of the dry matter intake (kg ash/kg DM)}
 
-\item{diet_ge}{Numeric. Average gross energy content of the diet (MJ/kg DM).}
+\item{diet_ash}{Numeric. Fraction of animal's gross energy that is excreted in urine (fraction).}
 }
 \value{
 Numeric. Total volatile solids (VS) excreted per animal per day, representing the organic material in livestock manure and consisting of both biodegradable and non-biodegradable fractions (kg VS/head/day).
@@ -43,23 +32,9 @@ a conversion factor of 18.45 MJ/kg DM.
 
 \strong{Implementation note (simplified coefficients).}
 This package uses simplified algebraic forms by species/method that are consistent with the
-structure of Eq. 10.24 under fixed/default assumptions for \eqn{UE} and \eqn{ASH}, and with
-digestibility supplied directly as a fraction (\code{diet_dig}).
-
-\strong{Species/method branches}
-\itemize{
-\item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
-\code{vs = dmi * (1.04 - diet_dig) * 0.92}.
-The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
+structure of Eq. 10.24.
+Specifically, in IPCC guidelines the the average gross energy content of the ration is used instead
 of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi.
-Second, it is assumed that Urinary energy is 4\% and the Ash content in feed is 8\%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
-}
-\item \strong{Swine} (\code{"PGS"}):
-\itemize{
-\item \code{vs = dmi * (1.02 - diet_dig) * 0.94}.
-It is assumed that urinary energy is 2\% and the ash content in feed is 6\% (based on IPCC, 2019). Therefore, GE × (GE + UE) becomes 1.02 and 1 – ASH becomes 0.94.
-}
-}
 }
 \references{
 IPCC. (2019). \emph{2019 Refinement to the 2006 IPCC Guidelines for National Greenhouse Gas Inventories}, Chapter 10: Emissions from

--- a/man/run_directemissions_manure.Rd
+++ b/man/run_directemissions_manure.Rd
@@ -25,6 +25,28 @@ the core calculation functions to produce emission estimates.
 This function is intended for internal use and performs no validation of inputs.
 Input data must be preloaded and properly formatted.
 }
+\section{TEMPORARY / This will have to be revised and incorporated with the full updated documentation.}{
+#' \strong{Implementation note (simplified coefficients).}
+This package uses simplified algebraic forms by species/method that are consistent with the
+structure of Eq. 10.24 under fixed/default assumptions for \eqn{UE} and \eqn{ASH}, and with
+digestibility supplied directly as a fraction (\code{diet_dig}).
+
+\strong{Species/method branches}
+\itemize{
+\item \strong{(\code{"CTL"}, \code{"BFL"}, \code{"CML"}, \code{"SHP"}, \code{"GTS"}):
+\code{vs = dmi * (1.04 - diet_dig) * 0.92}.
+The formula is a modification of the original IPCC equation. First, the average gross energy content of the ration is used instead
+of a fixed value of 18.45 MJ×kg DM-1. Thus, ge / diet_ge equals the daily intake, dmi.
+Second, it is assumed that Urinary energy is 4\% and the Ash content in feed is 8\%. Therefore, GE × (GE + UE) becomes 1.04 and 1 – ASH becomes 0.92
+}
+\item \strong{Swine} (\code{"PGS"}):
+\itemize{
+\item \code{vs = dmi * (1.02 - diet_dig) * 0.94}.
+It is assumed that urinary energy is 2\% and the ash content in feed is 6\% (based on IPCC, 2019). Therefore, GE × (GE + UE) becomes 1.02 and 1 – ASH becomes 0.94.
+}
+}
+}
+
 \examples{
 \dontrun{
 # Load example data and compute manure emissions

--- a/tests/testthat/test-directemissions_manure_core.R
+++ b/tests/testthat/test-directemissions_manure_core.R
@@ -1,26 +1,24 @@
 # ---- test calc_volatile_solids ----
-test_that("calc_volatile_solids produces expected results for cattle", {
+test_that("calc_volatile_solids produces expected results", {
   result <- calc_volatile_solids(
-    animal = "CTL",
     dmi = 5,
     diet_dig = 0.6,
-    diet_me = 9,
-    diet_ge = 18
-  )
+    urinary_energy_fraction = 0.04,
+    diet_ash = 0.08
+      )
   expect_length(result, 1)
   expect_true(result >= 0)
-  expect_equal(result, 5 * (1.04 - 0.6) * 0.92)
+  expect_equal(result, 5 * (1 - 0.6 + 0.04) * (1 - 0.08))
 })
 
-test_that("calc_volatile_solids handles PGS correctly", {
+test_that("calc_volatile_solids produces expected results", {
   result <- calc_volatile_solids(
-    animal = "PGS",
     dmi = 4,
     diet_dig = 0.7,
-    diet_me = 12,
-    diet_ge = 20
+    urinary_energy_fraction = 0.02,
+    diet_ash = 0.06
   )
-  expect_equal(result, 4 * (1.02 - 0.7) * 0.94)
+  expect_equal(result, 4 * (1 - 0.7 + 0.02) * (1 - 0.06))
 })
 
 
@@ -59,15 +57,13 @@ test_that("calc_volatile_solids handles PGS correctly", {
 
 test_that("calc_volatile_solids handles validation errors", {
   expect_error(
-    calc_volatile_solids("INVALID", 5, 0.6, 9, 18),
-    "animal"
-  )
-  expect_error(
-    calc_volatile_solids("CTL", -5, 0.6, 9, 18),
+    calc_volatile_solids(-5, 0.7, 0.02,
+                         0.06),
     "dmi"
   )
   expect_error(
-    calc_volatile_solids("CTL", 5, 2, 9, 18),
+    calc_volatile_solids(5, 2, 0.02,
+                         0.06),
     "diet_dig"
   )
 })


### PR DESCRIPTION
**Description**
This pull request refactors the `calc_volatile_solids` function to improve flexibility, transparency, and reusability by removing hard-coded assumptions related to ash content and urinary energy.

**Summary of Changes**
- Removed unnecessary function arguments: `animal`, `diet_me`, and `diet_ge`.
- Added `urinary_energy_fraction` and `diet_ash` as explicit function arguments.
- Rewrote the function logic to eliminate hard-coded assumptions for urinary energy fraction (UE) and dietary ash content (ASH).
- Updated function calls accordingly: Included default parameter values by species at the call level rather than embedding them in the function.

**Main implications**
The scientific function is now clean, modular, and no longer species-dependent. Assumptions related to UE and ASH are applied only at the run level, rather than being embedded in the function itself. This design allows users to override default species values and run the function using cohort-level UE and ASH estimates when such data are available.

NOTE: Documentation of the run_manure... will need to be revised later, once the module will be restructured.