### PR TITLE
[OP#290] Updated documentation for feed module (nutritional parameters)

### DIFF
--- a/R/feed_rations_core_model.R
+++ b/R/feed_rations_core_model.R
@@ -1,32 +1,32 @@
 #' Calculate feed digestibility fraction
 #'
-#' Computes species-specific feed digestibility fractions by feed item.
+#' Computes species-specific feed digestibility fractions by feed component.
 #'
 #' @param feed_digestible_energy_ruminant Numeric. Digestible energy content of a
-#'   feed item for ruminants, representing the energy absorbed by the animal after
+#'   feed component for ruminants, representing the energy absorbed by the animal after
 #'   fecal losses (MJ/kg DM).
 #' @param feed_digestible_energy_pigs Numeric. Digestible energy content of a feed
-#'   item for pigs, representing the energy absorbed by the animal after fecal
+#'   component for pigs, representing the energy absorbed by the animal after fecal
 #'   losses (MJ/kg DM).
 #' @param feed_metabolizable_energy_chicken Numeric. Metabolizable energy content
-#'   of a feed item for chickens, representing digestible energy minus energy
-#'   losses in urine and gaseous products of digestion (MJ/kg DM).
-#' @param feed_gross_energy Numeric. Gross energy content of a feed item,
+#'   of a feed component for chickens, representing digestible energy minus energy
+#'   losses in uric acid and gaseous products of digestion (MJ/kg DM).
+#' @param feed_gross_energy Numeric. Gross energy content of a feed component,
 #'   representing the total chemical energy released upon complete combustion of
 #'   the feed (MJ/kg DM).
 #'
 #' @return List with elements:
 #'   \describe{
 #'     \item{feed_digestibility_fraction_ruminant}{
-#'       Numeric. Digestibility of a feed item for ruminants, expressed as the ratio
+#'       Numeric. Digestibility of a feed component for ruminants, expressed as the ratio
 #'       of digestible energy to gross energy content (fraction).
 #'     }
 #'     \item{feed_digestibility_fraction_pigs}{
-#'       Numeric. Digestibility of a feed item for pigs, expressed as the ratio of
+#'       Numeric. Digestibility of a feed component for pigs, expressed as the ratio of
 #'       digestible energy to gross energy content (fraction).
 #'     }
 #'     \item{feed_digestibility_fraction_chicken}{
-#'       Numeric. Digestibility of a feed item for chickens, expressed as the ratio
+#'       Numeric. Digestibility of a feed component for chickens, expressed as the ratio
 #'       of metabolizable energy to gross energy content (fraction).
 #'     }
 #'   }
@@ -37,7 +37,7 @@
 #'
 #' For ruminants and pigs, usable energy is represented by \code{digestible_energy} (DE),
 #' which accounts for fecal energy losses. For chickens, \code{metabolizable_energy}
-#' (ME) is used instead of \code{digestible_energy} because urinary and fecal
+#' (ME) is used instead of \code{digestible_energy} because urinary losses (excreted as uric acid) and fecal
 #' excretions are voided together, making fecal energy losses difficult to measure
 #' separately. \code{metabolizable_energy} therefore provides a more appropriate and
 #' standard measure of usable dietary energy in poultry nutrition.
@@ -85,7 +85,7 @@ calc_feed_digestibility_fraction <- function(
 
 #' Calculate diet digestibility contribution for a ration component
 #'
-#' Applies species-specific digestibility parameters to a ration share to compute
+#' Applies species-specific digestibility parameters to a ration composition share to compute
 #' the contribution of a single feed component to total diet digestibility.
 #'
 #' @param species_short Character. Code identifying the livestock species.
@@ -99,20 +99,20 @@ calc_feed_digestibility_fraction <- function(
 #'     \item \code{GTS}: goats
 #'     \item \code{CHK}: chickens
 #'   }
-#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
-#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed component in the
+#'   total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 #'   each herd_id and cohort, proportions should sum to 1.
 #' @param feed_digestibility_fraction_ruminant Numeric. Digestibility of a feed
-#'   item for ruminants, expressed as the ratio of digestible energy to gross energy
+#'   component for ruminants, expressed as the ratio of digestible energy to gross energy
 #'   content (fraction).
-#' @param feed_digestibility_fraction_pigs Numeric. Digestibility of a feed item
+#' @param feed_digestibility_fraction_pigs Numeric. Digestibility of a feed component
 #'   for pigs, expressed as the ratio of digestible energy to gross energy content
 #'   (fraction).
 #' @param feed_digestibility_fraction_chicken Numeric. Digestibility of a feed
-#'   item for chickens, expressed as the ratio of metabolizable energy to gross
+#'   component for chickens, expressed as the ratio of metabolizable energy to gross
 #'   energy content (fraction).
 #'
-#' @return Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction).
+#' @return Numeric. Contribution of the feed component to total diet digestibility (fraction).
 #'
 #' @details
 #' The digestibility contribution uses the animal-specific digestibility ratio:
@@ -153,9 +153,9 @@ calc_diet_digestibility <- function(
 
 #' Calculate diet metabolizable energy contribution for a ration component
 #'
-#' Applies species-specific metabolizable energy parameters to a ration share to
+#' Applies species-specific metabolizable energy parameters to a ration composition share to
 #' compute the contribution of a single feed component to total diet metabolizable
-#' energy.
+#' energy content.
 #' 
 #' @param species_short Character. Code identifying the livestock species.
 #'   Supported values include:
@@ -168,21 +168,20 @@ calc_diet_digestibility <- function(
 #'     \item \code{GTS}: goats
 #'     \item \code{CHK}: chickens
 #'   }
-#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
-#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed component in the
+#'   total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 #'   each herd_id and cohort, proportions should sum to 1.
 #' @param feed_metabolizable_energy_ruminant Numeric. Metabolizable energy content
-#'   of a feed item for ruminants, representing digestible energy minus energy
+#'   of a feed component for ruminants, representing digestible energy minus energy
 #'   losses in urine and gaseous products of digestion (MJ/kg DM).
 #' @param feed_metabolizable_energy_pigs Numeric. Metabolizable energy content of a
-#'   feed item for pigs, representing digestible energy minus energy losses in
+#'   feed component for pigs, representing digestible energy minus energy losses in
 #'   urine and gaseous products of digestion (MJ/kg DM).
 #' @param feed_metabolizable_energy_chicken Numeric. Metabolizable energy content
-#'   of a feed item for chickens, representing digestible energy minus energy
-#'   losses in urine and gaseous products of digestion (MJ/kg DM).
+#'   of a feed component for chickens, representing digestible energy minus energy
+#'   losses in uric acid and gaseous products of digestion (MJ/kg DM).
 #'
-#' @return Numeric. Metabolizable energy contribution of the feed component to the
-#'   total diet metabolizable energy (MJ/kg DM).
+#' @return Numeric. Contribution of the feed component to total diet metabolizable energy content (MJ/kg DM).
 #'
 #' @details
 #' The metabolizable energy contribution uses the animal-specific parameter:
@@ -224,18 +223,17 @@ calc_diet_metabolizable_energy <- function(
 
 #' Calculate diet gross energy contribution for a ration component
 #'
-#' Computes the contribution of a single feed item to diet gross energy by
-#' weighting feed gross energy by its ration share.
+#' Computes the contribution of a single feed component to diet gross energy content by
+#' weighting feed gross energy by its ration composition share.
 #'
-#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
-#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed component in the
+#'   total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 #'   each herd_id and cohort, proportions should sum to 1.
-#' @param feed_gross_energy Numeric. Gross energy content of a feed item,
+#' @param feed_gross_energy Numeric. Gross energy content of a feed component,
 #'   representing the total chemical energy released upon complete combustion of
 #'   the feed (MJ/kg DM).
 #'
-#' @return Numeric. Average gross energy contribution of the diet component
-#'   (MJ/kg DM).
+#' @return Numeric. Contribution of the feed component to total diet gross energy content (MJ/kg DM).
 #'
 #' @details
 #' The gross energy contribution is defined as:
@@ -244,40 +242,38 @@ calc_diet_metabolizable_energy <- function(
 #' @export
 calc_diet_gross_energy <- function(feed_ration_fraction, feed_gross_energy) {
   validate_diet_gross_energy_inputs(feed_ration_fraction, feed_gross_energy)
-  # Contribution is ration share multiplied by gross energy content
+  # Contribution is ration composition share multiplied by gross energy content
   diet_gross_energy <- feed_ration_fraction * feed_gross_energy
   return(diet_gross_energy)
 }
 
 #' Calculate diet nitrogen contribution for a ration component
 #'
-#' Computes the contribution of a single feed item to diet nitrogen content by
-#' weighting feed nitrogen content by its ration share.
+#' Computes the contribution of a single feed component to diet nitrogen content by
+#' weighting feed nitrogen content by its ration composition share.
 #'
-#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
-#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed component in the
+#'   total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 #'   each herd_id and cohort, proportions should sum to 1.
-#' @param feed_nitrogen_content Numeric. Nitrogen content a feed item (kg N/kg DM).
+#' @param feed_nitrogen_content Numeric. Nitrogen content of a feed component (kg N/kg DM).
 #'
-#' @return Numeric. Average nitrogen content of diet (kg N/kg DM).
+#' @return Numeric. Contribution of the feed component to total diet nitrogen content (kg N/kg DM).
 #'
 #' @details
 #' The nitrogen contribution is defined as:
 #' \deqn{diet\_nitrogen = feed\_ration\_fraction \times feed\_nitrogen\_content}
 #'
-#' This helper is vectorized over its inputs.
-#'
 #' @export
 calc_diet_nitrogen_content <- function(feed_ration_fraction, feed_nitrogen_content) {
   validate_diet_nitrogen_inputs(feed_ration_fraction, feed_nitrogen_content)
-  # Contribution is ration share multiplied by nitrogen content
+  # Contribution is ration composition share multiplied by nitrogen content
   diet_nitrogen <- feed_ration_fraction * feed_nitrogen_content
   return(diet_nitrogen)
 }
 
 #' Calculate urinary energy fraction contribution for a ration component
 #' 
-#' Applies species-specific urinary energy fractions to a ration share to compute
+#' Applies species-specific urinary energy fractions to a ration composition share to compute
 #' the contribution of a feed component to urinary energy losses.
 #'
 #' @param species_short Character. Code identifying the livestock species.
@@ -291,18 +287,18 @@ calc_diet_nitrogen_content <- function(feed_ration_fraction, feed_nitrogen_conte
 #'     \item \code{GTS}: goats
 #'     \item \code{CHK}: chickens
 #'   }
-#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
-#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed component in the
+#'   total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 #'   each herd_id and cohort, proportions should sum to 1.
 #' @param feed_urinary_energy_ruminant Numeric. Fraction of feed's gross energy that
 #'   is excreted in urine for ruminants (fraction).
 #' @param feed_urinary_energy_pigs Numeric. Fraction of feed's gross energy that
 #'   is excreted in urine for pigs (fraction).
 #' @param feed_urinary_energy_chicken Numeric. Fraction of feed's gross energy that
-#'   is excreted in urine for chickens (fraction). Default = 0.
+#'   is excreted in uric acid for chickens (fraction). Default = 0.
 #'
-#' @return Numeric. Fraction of feed's gross energy that is excreted in urine
-#'   (fraction).
+#' @return Numeric. Contribution of the feed component to the fraction of total diet
+#'  gross energy that is excreted in urine (fraction).
 #'
 #' @details
 #' The urinary energy fraction contribution uses the animal-specific parameter:
@@ -349,17 +345,16 @@ calc_urinary_energy_fraction <- function(
 
 #' Calculate diet ash contribution for a ration component
 #'
-#' Computes the contribution of a single feed item to diet ash content by
-#' weighting feed ash content by its ration share.
+#' Computes the contribution of a single feed component to diet ash content by
+#' weighting feed ash content by its ration composition share.
 #'
-#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
-#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed component in the
+#'   total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 #'   each herd_id and cohort, proportions should sum to 1.
-#' @param feed_ash_content Numeric. Average ash content by feed item, calculated as
+#' @param feed_ash_content Numeric. Average ash content by feed component, expressed as
 #'   a fraction of the dry matter intake (g ash/100g DM).
 #'
-#' @return Numeric. Average ash content contribution of the diet component,
-#'   calculated as a fraction of the dry matter intake (kg ash/kg DM).
+#' @return Numeric. Contribution of the feed component to total diet ash content (kg ash/kg DM).
 #'
 #' @details
 #' The ash contribution is defined as:
@@ -371,7 +366,7 @@ calc_urinary_energy_fraction <- function(
 calc_diet_ash <- function(feed_ration_fraction, feed_ash_content) {
   validate_diet_ash_inputs(feed_ration_fraction, feed_ash_content)
 
-  # Contribution is ration share multiplied by feed_ash_content
+  # Contribution is ration composition share multiplied by feed_ash_content
   diet_ash <- feed_ration_fraction * feed_ash_content / 100
 
   return(diet_ash)

--- a/R/feed_rations_core_model.R
+++ b/R/feed_rations_core_model.R
@@ -1,27 +1,46 @@
 #' Calculate feed digestibility fraction
 #'
-#' Computes digestibility as the ratio of digestible or metabolizable energy
-#' to gross energy.
+#' Computes species-specific feed digestibility fractions by feed item.
 #'
-#' @param feed_digestible_energy_ruminant Numeric. Digestible energy for ruminants
-#'   (same units as `feed_gross_energy`).
-#' @param feed_digestible_energy_pigs Numeric. Digestible energy for pigs
-#'   (same units as `feed_gross_energy`).
-#' @param feed_metabolizable_energy_chicken Numeric. Metabolizable energy for chickens
-#'   (same units as `feed_gross_energy`).
-#' @param feed_gross_energy Numeric. Gross energy (same units as
-#'   `feed_digestible_energy_ruminant`, `feed_digestible_energy_pigs`,
-#'   and `feed_metabolizable_energy_chicken`).
+#' @param feed_digestible_energy_ruminant Numeric. Digestible energy content of a
+#'   feed item for ruminants, representing the energy absorbed by the animal after
+#'   fecal losses (MJ/kg DM).
+#' @param feed_digestible_energy_pigs Numeric. Digestible energy content of a feed
+#'   item for pigs, representing the energy absorbed by the animal after fecal
+#'   losses (MJ/kg DM).
+#' @param feed_metabolizable_energy_chicken Numeric. Metabolizable energy content
+#'   of a feed item for chickens, representing digestible energy minus energy
+#'   losses in urine and gaseous products of digestion (MJ/kg DM).
+#' @param feed_gross_energy Numeric. Gross energy content of a feed item,
+#'   representing the total chemical energy released upon complete combustion of
+#'   the feed (MJ/kg DM).
 #'
-#' @return List. Digestibility fractions (unitless) with elements:
-#'   `feed_digestibility_fraction_ruminant`, `feed_digestibility_fraction_pigs`,
-#'   `feed_digestibility_fraction_chicken`.
-#'
+#' @return List with elements:
+#'   \describe{
+#'     \item{feed_digestibility_fraction_ruminant}{
+#'       Numeric. Digestibility of a feed item for ruminants, expressed as the ratio
+#'       of digestible energy to gross energy content (fraction).
+#'     }
+#'     \item{feed_digestibility_fraction_pigs}{
+#'       Numeric. Digestibility of a feed item for pigs, expressed as the ratio of
+#'       digestible energy to gross energy content (fraction).
+#'     }
+#'     \item{feed_digestibility_fraction_chicken}{
+#'       Numeric. Digestibility of a feed item for chickens, expressed as the ratio
+#'       of metabolizable energy to gross energy content (fraction).
+#'     }
+#'   }
+#'   
 #' @details
-#' The digestibility ratio is defined as:
-#' \deqn{feed\_digestibility\_fraction = feed\_digestible\_energy / feed\_gross\_energy}
+#' Digestibility is computed as the ratio of usable energy to gross energy:
+#' \deqn{feed\_digestibility\_fraction = usable\_energy / feed\_gross\_energy}
 #'
-#' This helper is vectorized over its inputs.
+#' For ruminants and pigs, usable energy is represented by \code{digestible_energy} (DE),
+#' which accounts for fecal energy losses. For chickens, \code{metabolizable_energy}
+#' (ME) is used instead of \code{digestible_energy} because urinary and fecal
+#' excretions are voided together, making fecal energy losses difficult to measure
+#' separately. \code{metabolizable_energy} therefore provides a more appropriate and
+#' standard measure of usable dietary energy in poultry nutrition.
 #'
 #' @export
 calc_feed_digestibility_fraction <- function(
@@ -66,28 +85,45 @@ calc_feed_digestibility_fraction <- function(
 
 #' Calculate diet digestibility contribution for a ration component
 #'
-#' Applies species-specific digestibility parameters to a ration share.
+#' Applies species-specific digestibility parameters to a ration share to compute
+#' the contribution of a single feed component to total diet digestibility.
 #'
-#' @param species_short Character. Species short code. Supported values include
-#'   ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}),
-#'   chickens (\code{CHK}), and pigs (\code{PGS}).
-#' @param feed_ration_fraction Numeric. Ration share for the feed component (fraction).
-#' @param feed_digestibility_fraction_ruminant Numeric. Digestibility ratio for ruminants.
-#' @param feed_digestibility_fraction_pigs Numeric. Digestibility ratio for pigs.
-#' @param feed_digestibility_fraction_chicken Numeric. Digestibility ratio for chickens.
+#' @param species_short Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'     \item \code{CHK}: chickens
+#'   }
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
+#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#'   each herd_id and cohort, proportions should sum to 1.
+#' @param feed_digestibility_fraction_ruminant Numeric. Digestibility of a feed
+#'   item for ruminants, expressed as the ratio of digestible energy to gross energy
+#'   content (fraction).
+#' @param feed_digestibility_fraction_pigs Numeric. Digestibility of a feed item
+#'   for pigs, expressed as the ratio of digestible energy to gross energy content
+#'   (fraction).
+#' @param feed_digestibility_fraction_chicken Numeric. Digestibility of a feed
+#'   item for chickens, expressed as the ratio of metabolizable energy to gross
+#'   energy content (fraction).
 #'
-#' @return Numeric. Digestibility contribution for the ration component.
+#' @return Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction).
 #'
 #' @details
 #' The digestibility contribution uses the animal-specific digestibility ratio:
 #' \itemize{
-#'   \item Ruminants: \code{feed_ration_fraction * feed_digestibility_fraction_ruminant}
-#'   \item Chickens: \code{feed_ration_fraction * feed_digestibility_fraction_chicken}
-#'   \item Pigs: \code{feed_ration_fraction * feed_digestibility_fraction_pigs}
+#'   \item Ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}):
+#'     \code{feed_ration_fraction * feed_digestibility_fraction_ruminant}
+#'   \item Chickens (\code{CHK}):
+#'     \code{feed_ration_fraction * feed_digestibility_fraction_chicken}
+#'   \item Pigs (\code{PGS}):
+#'     \code{feed_ration_fraction * feed_digestibility_fraction_pigs}
 #' }
-#'
-#' This helper is vectorized over its inputs.
-#'
 #' @export
 calc_diet_digestibility <- function(
     species_short,
@@ -117,27 +153,47 @@ calc_diet_digestibility <- function(
 
 #' Calculate diet metabolizable energy contribution for a ration component
 #'
-#' Applies species-specific metabolizable energy parameters to a ration share.
+#' Applies species-specific metabolizable energy parameters to a ration share to
+#' compute the contribution of a single feed component to total diet metabolizable
+#' energy.
+#' 
+#' @param species_short Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'     \item \code{CHK}: chickens
+#'   }
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
+#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#'   each herd_id and cohort, proportions should sum to 1.
+#' @param feed_metabolizable_energy_ruminant Numeric. Metabolizable energy content
+#'   of a feed item for ruminants, representing digestible energy minus energy
+#'   losses in urine and gaseous products of digestion (MJ/kg DM).
+#' @param feed_metabolizable_energy_pigs Numeric. Metabolizable energy content of a
+#'   feed item for pigs, representing digestible energy minus energy losses in
+#'   urine and gaseous products of digestion (MJ/kg DM).
+#' @param feed_metabolizable_energy_chicken Numeric. Metabolizable energy content
+#'   of a feed item for chickens, representing digestible energy minus energy
+#'   losses in urine and gaseous products of digestion (MJ/kg DM).
 #'
-#' @param species_short Character. Species short code. Supported values include
-#'   ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}),
-#'   chickens (\code{CHK}), and pigs (\code{PGS}).
-#' @param feed_ration_fraction Numeric. Ration share for the feed component (fraction).
-#' @param feed_metabolizable_energy_ruminant Numeric. Metabolizable energy for ruminants.
-#' @param feed_metabolizable_energy_pigs Numeric. Metabolizable energy for pigs.
-#' @param feed_metabolizable_energy_chicken Numeric. Metabolizable energy for chickens.
-#'
-#' @return Numeric. Metabolizable energy contribution for the ration component.
+#' @return Numeric. Metabolizable energy contribution of the feed component to the
+#'   total diet metabolizable energy (MJ/kg DM).
 #'
 #' @details
 #' The metabolizable energy contribution uses the animal-specific parameter:
 #' \itemize{
-#'   \item Ruminants: \code{feed_ration_fraction * feed_metabolizable_energy_ruminant}
-#'   \item Chickens: \code{feed_ration_fraction * feed_metabolizable_energy_chicken}
-#'   \item Pigs: \code{feed_ration_fraction * feed_metabolizable_energy_pigs}
+#'   \item Ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}):
+#'     \code{feed_ration_fraction * feed_metabolizable_energy_ruminant}
+#'   \item Chickens (\code{CHK}):
+#'     \code{feed_ration_fraction * feed_metabolizable_energy_chicken}
+#'   \item Pigs (\code{PGS}):
+#'     \code{feed_ration_fraction * feed_metabolizable_energy_pigs}
 #' }
-#'
-#' This helper is vectorized over its inputs.
 #'
 #' @export
 calc_diet_metabolizable_energy <- function(
@@ -168,18 +224,22 @@ calc_diet_metabolizable_energy <- function(
 
 #' Calculate diet gross energy contribution for a ration component
 #'
-#' Computes gross energy contribution from a ration share and gross energy input.
+#' Computes the contribution of a single feed item to diet gross energy by
+#' weighting feed gross energy by its ration share.
 #'
-#' @param feed_ration_fraction Numeric. Ration share for the feed component (fraction).
-#' @param feed_gross_energy Numeric. Gross energy content (MJ/kg DM).
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
+#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#'   each herd_id and cohort, proportions should sum to 1.
+#' @param feed_gross_energy Numeric. Gross energy content of a feed item,
+#'   representing the total chemical energy released upon complete combustion of
+#'   the feed (MJ/kg DM).
 #'
-#' @return Numeric. Gross energy contribution for the ration component.
+#' @return Numeric. Average gross energy contribution of the diet component
+#'   (MJ/kg DM).
 #'
 #' @details
 #' The gross energy contribution is defined as:
 #' \deqn{diet\_gross\_energy = feed\_ration\_fraction \times feed\_gross\_energy}
-#'
-#' This helper is vectorized over its inputs.
 #'
 #' @export
 calc_diet_gross_energy <- function(feed_ration_fraction, feed_gross_energy) {
@@ -191,12 +251,15 @@ calc_diet_gross_energy <- function(feed_ration_fraction, feed_gross_energy) {
 
 #' Calculate diet nitrogen contribution for a ration component
 #'
-#' Computes nitrogen contribution from a ration share and nitrogen content.
+#' Computes the contribution of a single feed item to diet nitrogen content by
+#' weighting feed nitrogen content by its ration share.
 #'
-#' @param feed_ration_fraction Numeric. Ration share for the feed component (fraction).
-#' @param feed_nitrogen_content Numeric. Nitrogen content (kg N/kg DM).
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
+#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#'   each herd_id and cohort, proportions should sum to 1.
+#' @param feed_nitrogen_content Numeric. Nitrogen content a feed item (kg N/kg DM).
 #'
-#' @return Numeric. Nitrogen contribution for the ration component.
+#' @return Numeric. Average nitrogen content of diet (kg N/kg DM).
 #'
 #' @details
 #' The nitrogen contribution is defined as:
@@ -213,30 +276,49 @@ calc_diet_nitrogen_content <- function(feed_ration_fraction, feed_nitrogen_conte
 }
 
 #' Calculate urinary energy fraction contribution for a ration component
+#' 
+#' Applies species-specific urinary energy fractions to a ration share to compute
+#' the contribution of a feed component to urinary energy losses.
 #'
-#' Applies species-specific urinary energy parameters to a ration share.
-#'
-#' @param species_short Character. Species short code. Supported values include
-#'   ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}),
-#'   chickens (\code{CHK}), and pigs (\code{PGS}).
-#' @param feed_ration_fraction Numeric proportion of a specific feed item in the total ration,
-#'  expressed as its fraction of diet dry matter (fraction)
+#' @param species_short Character. Code identifying the livestock species.
+#'   Supported values include:
+#'   \itemize{
+#'     \item \code{PGS}: pigs
+#'     \item \code{CML}: camels
+#'     \item \code{CTL}: cattle
+#'     \item \code{BFL}: buffalo
+#'     \item \code{SHP}: sheep
+#'     \item \code{GTS}: goats
+#'     \item \code{CHK}: chickens
+#'   }
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
+#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#'   each herd_id and cohort, proportions should sum to 1.
 #' @param feed_urinary_energy_ruminant Numeric. Fraction of feed's gross energy that
-#'  is excreted in urine for ruminants (fraction).
+#'   is excreted in urine for ruminants (fraction).
 #' @param feed_urinary_energy_pigs Numeric. Fraction of feed's gross energy that
-#'  is excreted in urine for pigs (fraction).
+#'   is excreted in urine for pigs (fraction).
 #' @param feed_urinary_energy_chicken Numeric. Fraction of feed's gross energy that
-#'  is excreted in urine for chickens (fraction). Default to 0.
+#'   is excreted in urine for chickens (fraction). Default = 0.
 #'
-#' @return Numeric. Fraction of feed's gross energy that is excreted in urine (fraction).
+#' @return Numeric. Fraction of feed's gross energy that is excreted in urine
+#'   (fraction).
 #'
 #' @details
 #' The urinary energy fraction contribution uses the animal-specific parameter:
 #' \itemize{
-#'   \item Ruminants: \code{feed_ration_fraction * feed_urinary_energy_ruminant}
-#'   \item Chickens: \code{feed_ration_fraction * feed_urinary_energy_chicken}
-#'   \item Pigs: \code{feed_ration_fraction * feed_urinary_energy_pigs}
+#'   \item Ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}):
+#'     \code{feed_ration_fraction * feed_urinary_energy_ruminant}
+#'   \item Chickens (\code{CHK}):
+#'     \code{feed_ration_fraction * feed_urinary_energy_chicken}
+#'   \item Pigs (\code{PGS}):
+#'     \code{feed_ration_fraction * feed_urinary_energy_pigs}
 #' }
+#' 
+#' For chickens, \code{feed_urinary_energy_chicken} defaults to 0 because urinary
+#' energy losses are accounted for within \code{metabolizable_energy} in poultry
+#' nutrition (urine and feces are excreted together), and are therefore not modeled
+#' as a separate fraction of gross energy.
 #'
 #' @export
 calc_urinary_energy_fraction <- function(
@@ -267,21 +349,23 @@ calc_urinary_energy_fraction <- function(
 
 #' Calculate diet ash contribution for a ration component
 #'
-#' Computes ash contribution from a ration share and ash content.
+#' Computes the contribution of a single feed item to diet ash content by
+#' weighting feed ash content by its ration share.
 #'
-#' @param feed_ration_fraction Numeric proportion of a specific feed item in the total ration,
-#'  expressed as its fraction of diet dry matter (fraction).
-#' @param feed_ash_content Numeric. Average ash content by feed item,
-#' calculated as a fraction of the dry matter intake (g ash/100g DM).
+#' @param feed_ration_fraction Numeric. Proportion of a specific feed item in the
+#'   total ration, expressed as its fraction of diet dry matter (fraction). Within
+#'   each herd_id and cohort, proportions should sum to 1.
+#' @param feed_ash_content Numeric. Average ash content by feed item, calculated as
+#'   a fraction of the dry matter intake (g ash/100g DM).
 #'
-#' @return Numeric. Average ash content of feed, calculated as a fraction of
-#'  the dry matter intake (kg ash/kg DM).
+#' @return Numeric. Average ash content contribution of the diet component,
+#'   calculated as a fraction of the dry matter intake (kg ash/kg DM).
 #'
 #' @details
 #' The ash contribution is defined as:
 #' \deqn{diet\_ash = feed\_ration\_fraction \times feed\_ash\_content / 100}
 #'
-#' Ash content is expressed as a percentage; the result is a fraction.
+#' Ash content is expressed as a percentage (g/100g DM); the result is a fraction.
 #'
 #' @export
 calc_diet_ash <- function(feed_ration_fraction, feed_ash_content) {

--- a/R/run_feed_rations.R
+++ b/R/run_feed_rations.R
@@ -1,27 +1,120 @@
 #' Calculate Feed Intake Metrics
 #'
-#' Computes cohort-level dietary energy, digestibility, and nitrogen intake
-#' from feed rations and nutritional parameters. Assumes inputs are pre-cleaned.
+#' Compute cohort-level diet composition metrics (gross and metabolizable energy
+#' content, digestibility, nitrogen content, urinary energy losses, and ash
+#' content) from cohort-level feed ration shares and feed item nutrient
+#' parameters.
 #'
-#' @param rations_share A data.table containing feed shares per cohort. Must include:
-#'   - `herd_id`, `animal`, `feed_name`, `feed_id`, `cohort_short`, and
-#'     `feed_ration_fraction`.
-#'   - Note that `feed_name` is optional but should be consistent with `feed_id`
-#'   for a coherent result.
-#' @param feed_params A data.table of nutrient parameters. Must include:
-#'   - `feed_id`, `feed_gross_energy`,
-#'     `feed_digestible_energy_ruminant`, `feed_digestible_energy_pigs`,
-#'     `feed_metabolizable_energy_ruminant`, `feed_metabolizable_energy_pigs`,
-#'     `feed_metabolizable_energy_chicken`, `feed_nitrogen_content`,
-#'     `feed_urinary_energy_ruminant`, `feed_urinary_energy_pigs`,
-#'      `feed_ash_content`.
-#'   - Note that `category` and `feed_name` are optional but should be consistent with `feed_id`
-#'   for a coherent result.
+#' @param rations_share data.table. Cohort-level feed ration shares with the
+#'   following minimum data requirement:
+#'   \describe{
+#'     \item{herd_id}{Character. Unique identifier for the herd, repeated for each
+#'     cohort belonging to the same herd.}
+#'     \item{animal}{Character. Livestock category name used to map to a species
+#'     short code via internal lookup (e.g., for applying species-specific energy
+#'     parameters).}
+#'     \item{cohort_short}{
+#'     Character. Sex- and age-specific cohort code describing the production stage
+#'     of the animals. Supported values include:
+#'     \itemize{
+#'     \item \code{FA}: adult females (from age at first parturition)
+#'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
+#'     \item \code{FJ}: juvenile females (from birth to weaning)
+#'     \item \code{MA}: adult males (from age at first breeding)
+#'     \item \code{MS}: sub-adult males (from weaning to age at first breeding)
+#'     \item \code{MJ}: juvenile males (from birth to weaning)
+#'   }
+#'   }
+#'     \item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+#'     \item{feed_name}{Character. Feed item name (optional, for readability and
+#'     reporting). If provided, should be consistent with \code{feed_id}.}
+#'     \item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the total ration, expressed as its fraction of diet dry matter (fraction). 
+#'     Within each herd_id and cohort, proportions should sum to 1.}
+#'   }
 #'
-#' @return A data.table summarized by `herd_id`, `animal`, and `cohort_short` with:
-#'   - `diet_gross_energy`, `diet_metabolizable_energy`,
-#'     `diet_nitrogen`, `diet_digestibility_fraction`,
-#'     `urinary_energy_fraction`, `diet_ash`
+#' @param feed_params data.table. Feed nutrient parameters with the following
+#'   minimum data requirement:
+#'   \describe{
+#'     \item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+#'     \item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+#'     representing the total chemical energy released upon complete combustion of
+#'     the feed (MJ/kg DM).}
+#'     \item{feed_digestible_energy_ruminant}{Numeric. Digestible energy content of
+#'     a feed item for ruminants, representing the energy absorbed by the animal
+#'     after fecal losses (MJ/kg DM).}
+#'     \item{feed_digestible_energy_pigs}{Numeric. Digestible energy content of a
+#'     feed item for pigs, representing the energy absorbed by the animal after
+#'     fecal losses (MJ/kg DM).}
+#'     \item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy
+#'     content of a feed item for ruminants, representing digestible energy minus
+#'     energy losses in urine and gaseous products of digestion (MJ/kg DM).}
+#'     \item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy content
+#'     of a feed item for pigs, representing digestible energy minus energy losses
+#'     in urine and gaseous products of digestion (MJ/kg DM).}
+#'     \item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy
+#'     content of a feed item for chickens, representing digestible energy minus
+#'     energy losses in urine and gaseous products of digestion (MJ/kg DM).}
+#'     \item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed item
+#'     (kg N/kg DM).}
+#'     \item{feed_urinary_energy_ruminant}{Numeric. Fraction of feed's gross energy
+#'     that is excreted in urine for ruminants (fraction).}
+#'     \item{feed_urinary_energy_pigs}{Numeric. Fraction of feed's gross energy
+#'     that is excreted in urine for pigs (fraction).}
+#'     \item{feed_ash_content}{Numeric. Average ash content by feed item, calculated
+#'     as a fraction of the dry matter intake (g ash/100g DM).}
+#'     \item{category}{Character. Feed category (optional). If provided, should be
+#'     consistent with \code{feed_id} for a coherent result.}
+#'     \item{feed_name}{Character. Feed item name (optional, for readability and
+#'     reporting). If provided, should be consistent with \code{feed_id}.}
+#'   }
+#'
+#' @return data.table. Cohort-level diet metrics summarized by \code{herd_id},
+#'   \code{animal}, and \code{cohort_short} with the following columns:
+#'   \describe{
+#'     \item{diet_gross_energy}{Numeric. Average gross energy content of the diet
+#'     (MJ/kg DM).}
+#'     \item{diet_metabolizable_energy}{Numeric. Average metabolizable energy
+#'     content of the diet (MJ/kg DM).}
+#'     \item{diet_nitrogen}{Numeric. Average nitrogen content of diet (kg N/kg DM).}
+#'     \item{diet_digestibility_fraction}{Numeric. Average digestibility of the feed
+#'     ration, expressed as ratio of digestible (or metabolizable, for poultry) to
+#'     gross energy content (fraction).}
+#'     \item{urinary_energy_fraction}{Numeric. Fraction of feed's gross energy that
+#'     is excreted in urine (fraction).}
+#'     \item{diet_ash}{Numeric. Average ash content of feed, calculated as a fraction
+#'     of the dry matter intake (kg ash/kg DM).}
+#'   }
+#'
+#' @details
+#' This function joins \code{rations_share} with \code{feed_params} by \code{feed_id},
+#' maps \code{animal} to a species short code, and computes ration-weighted diet
+#' metrics by cohort.
+#'
+#' The following calculation sequence is applied:
+#' \enumerate{
+#'   \item Species-specific digestibility ratios are computed from energy parameters
+#'   and \code{feed_gross_energy} using \code{\link{calc_feed_digestibility_fraction}}.
+#'   \item Feed-level contributions are computed as ration-weighted values:
+#'   \itemize{
+#'     \item gross energy using \code{\link{calc_diet_gross_energy}}
+#'     \item nitrogen using \code{\link{calc_diet_nitrogen_content}}
+#'     \item digestibility using \code{\link{calc_diet_digestibility}}
+#'     \item metabolizable energy using \code{\link{calc_diet_metabolizable_energy}}
+#'     \item urinary energy fraction using \code{\link{calc_urinary_energy_fraction}}
+#'     \item ash using \code{\link{calc_diet_ash}}
+#'   }
+#'   \item Cohort-level diet metrics are obtained by summing contributions across
+#'   feed items within each \code{herd_id}, \code{animal}, and \code{cohort_short}.
+#' }
+#'
+#' @seealso
+#' \code{\link{calc_feed_digestibility_fraction}},
+#' \code{\link{calc_diet_gross_energy}},
+#' \code{\link{calc_diet_nitrogen_content}},
+#' \code{\link{calc_diet_digestibility}},
+#' \code{\link{calc_diet_metabolizable_energy}},
+#' \code{\link{calc_urinary_energy_fraction}},
+#' \code{\link{calc_diet_ash}}
 #'
 #' @examples
 #' \dontrun{

--- a/R/run_feed_rations.R
+++ b/R/run_feed_rations.R
@@ -1,11 +1,11 @@
 #' Calculate Feed Intake Metrics
 #'
-#' Compute cohort-level diet composition metrics (gross and metabolizable energy
+#' Computes cohort-level diet nutritional metrics (gross and metabolizable energy
 #' content, digestibility, nitrogen content, urinary energy losses, and ash
-#' content) from cohort-level feed ration shares and feed item nutrient
+#' content) from cohort-level feed ration composition shares and feed component nutrient
 #' parameters.
 #'
-#' @param rations_share data.table. Cohort-level feed ration shares with the
+#' @param rations_share data.table. Cohort-level feed ration composition shares with the
 #'   following minimum data requirement:
 #'   \describe{
 #'     \item{herd_id}{Character. Unique identifier for the herd, repeated for each
@@ -35,51 +35,51 @@
 #'     \item \code{MJ}: juvenile males (from birth to weaning)
 #'   }
 #'   }
-#'     \item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
-#'     \item{feed_name}{Character. Feed item name (optional, for readability and
-#'     reporting). If provided, should be consistent with \code{feed_id}.}
-#'     \item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the total ration, expressed as its fraction of diet dry matter (fraction). 
+#'     \item{feed_id}{Character. Unique identifier for the feed component, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+#'     \item{feed_name}{Character. feed component name (optional, for readability and
+#'     reporting). If provided, it should uniquely identify the same feed component as \code{feed_id}.}
+#'     \item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the total ration, expressed as its fraction of diet dry matter intake (fraction). 
 #'     Within each herd_id and cohort, proportions should sum to 1.}
 #'   }
 #'   
 #'
-#' @param feed_params data.table. Feed nutrient parameters with the following
+#' @param feed_params data.table. Feed nutritional parameters with the following
 #'   minimum data requirement:
 #'   \describe{
-#'     \item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
-#'     \item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+#'     \item{feed_id}{Character. Unique identifier for the feed component, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+#'     \item{feed_gross_energy}{Numeric. Gross energy content of a feed component,
 #'     representing the total chemical energy released upon complete combustion of
 #'     the feed (MJ/kg DM).}
 #'     \item{feed_digestible_energy_ruminant}{Numeric. Digestible energy content of
-#'     a feed item for ruminants, representing the energy absorbed by the animal
+#'     a feed component for ruminants, representing the energy absorbed by the animal
 #'     after fecal losses (MJ/kg DM).}
 #'     \item{feed_digestible_energy_pigs}{Numeric. Digestible energy content of a
-#'     feed item for pigs, representing the energy absorbed by the animal after
+#'     feed component for pigs, representing the energy absorbed by the animal after
 #'     fecal losses (MJ/kg DM).}
 #'     \item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy
-#'     content of a feed item for ruminants, representing digestible energy minus
+#'     content of a feed component for ruminants, representing digestible energy minus
 #'     energy losses in urine and gaseous products of digestion (MJ/kg DM).}
 #'     \item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy content
-#'     of a feed item for pigs, representing digestible energy minus energy losses
+#'     of a feed component for pigs, representing digestible energy minus energy losses
 #'     in urine and gaseous products of digestion (MJ/kg DM).}
 #'     \item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy
-#'     content of a feed item for chickens, representing digestible energy minus
-#'     energy losses in urine and gaseous products of digestion (MJ/kg DM).}
-#'     \item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed item
+#'     content of a feed component for chickens, representing digestible energy minus
+#'     energy losses in uric acid and gaseous products of digestion (MJ/kg DM).}
+#'     \item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed component
 #'     (kg N/kg DM).}
 #'     \item{feed_urinary_energy_ruminant}{Numeric. Fraction of feed's gross energy
 #'     that is excreted in urine for ruminants (fraction).}
 #'     \item{feed_urinary_energy_pigs}{Numeric. Fraction of feed's gross energy
 #'     that is excreted in urine for pigs (fraction).}
-#'     \item{feed_ash_content}{Numeric. Average ash content by feed item, calculated
+#'     \item{feed_ash_content}{Numeric. Average ash content by feed component, calculated
 #'     as a fraction of the dry matter intake (g ash/100g DM).}
-#'     \item{category}{Character. Feed category (optional). If provided, should be
-#'     consistent with \code{feed_id} for a coherent result.}
-#'     \item{feed_name}{Character. Feed item name (optional, for readability and
-#'     reporting). If provided, should be consistent with \code{feed_id}.}
+#'     \item{category}{Character. Feed category (optional). If provided, it should be
+#'     used consistently  with \code{feed_id}, for a coherent result.}
+#'     \item{feed_name}{Character. feed component name (optional, for readability and
+#'     reporting). If provided, it should uniquely identify the same feed component as \code{feed_id}.}
 #'   }
 #'
-#' @return data.table. Cohort-level diet metrics summarized by \code{herd_id},
+#' @return data.table. Cohort-level nutritional metrics summarized by \code{herd_id},
 #'   \code{animal}, and \code{cohort_short} with the following columns:
 #'   \describe{
 #'     \item{diet_gross_energy}{Numeric. Average gross energy content of the diet
@@ -98,14 +98,14 @@
 #'
 #' @details
 #' This function joins \code{rations_share} with \code{feed_params} by \code{feed_id},
-#' maps \code{animal} to a species short code, and computes ration-weighted diet
+#' maps \code{animal} to a species short code, and computes ration-weighted nutritional
 #' metrics by cohort.
 #'
 #' The following calculation sequence is applied:
 #' \enumerate{
 #'   \item Species-specific digestibility ratios are computed from energy parameters
 #'   and \code{feed_gross_energy} using \code{\link{calc_feed_digestibility_fraction}}.
-#'   \item Feed-level contributions are computed as ration-weighted values:
+#'   \item Contributions of each feed component are computed as ration-weighted values:
 #'   \itemize{
 #'     \item gross energy using \code{\link{calc_diet_gross_energy}}
 #'     \item nitrogen using \code{\link{calc_diet_nitrogen_content}}
@@ -114,8 +114,8 @@
 #'     \item urinary energy fraction using \code{\link{calc_urinary_energy_fraction}}
 #'     \item ash using \code{\link{calc_diet_ash}}
 #'   }
-#'   \item Cohort-level diet metrics are obtained by summing contributions across
-#'   feed items within each \code{herd_id}, \code{animal}, and \code{cohort_short}.
+#'   \item Cohort-level nutritional metrics are obtained for the whole feed ration by summing contributions across
+#'   feed components within each \code{herd_id}, \code{animal}, and \code{cohort_short}.
 #' }
 #'
 #' @seealso

--- a/R/run_feed_rations.R
+++ b/R/run_feed_rations.R
@@ -10,9 +10,19 @@
 #'   \describe{
 #'     \item{herd_id}{Character. Unique identifier for the herd, repeated for each
 #'     cohort belonging to the same herd.}
-#'     \item{animal}{Character. Livestock category name used to map to a species
-#'     short code via internal lookup (e.g., for applying species-specific energy
-#'     parameters).}
+#'     \item{animal}{
+#'     Character. Livestock category name used to map to a species short code via an
+#'     internal lookup table. Supported values include:
+#'     \itemize{
+#'     \item \code{Cattle}
+#'     \item \code{Buffalo}
+#'     \item \code{Sheep}
+#'     \item \code{Goats}
+#'     \item \code{Chicken}
+#'     \item \code{Pigs}
+#'     \item \code{Camels}
+#'     }
+#'     }
 #'     \item{cohort_short}{
 #'     Character. Sex- and age-specific cohort code describing the production stage
 #'     of the animals. Supported values include:
@@ -31,6 +41,7 @@
 #'     \item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the total ration, expressed as its fraction of diet dry matter (fraction). 
 #'     Within each herd_id and cohort, proportions should sum to 1.}
 #'   }
+#'   
 #'
 #' @param feed_params data.table. Feed nutrient parameters with the following
 #'   minimum data requirement:

--- a/R/run_feed_rations.R
+++ b/R/run_feed_rations.R
@@ -145,9 +145,7 @@
 #' @importFrom data.table fifelse data.table
 run_feed_rations <- function(
     rations_share,
-    feed_params = data.table::fread(
-      system.file("extdata/Parameters/feed/feed_params.csv", package = "gleam")
-    )
+    feed_params
 ) {
   # --- Step 1: Validate inputs -----------------------------------------------
   validate_feed_rations_inputs(rations_share, feed_params)

--- a/man/calc_diet_ash.Rd
+++ b/man/calc_diet_ash.Rd
@@ -7,20 +7,19 @@
 calc_diet_ash(feed_ration_fraction, feed_ash_content)
 }
 \arguments{
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
-total ration, expressed as its fraction of diet dry matter (fraction). Within
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the
+total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_ash_content}{Numeric. Average ash content by feed item, calculated as
+\item{feed_ash_content}{Numeric. Average ash content by feed component, expressed as
 a fraction of the dry matter intake (g ash/100g DM).}
 }
 \value{
-Numeric. Average ash content contribution of the diet component,
-calculated as a fraction of the dry matter intake (kg ash/kg DM).
+Numeric. Contribution of the feed component to total diet ash content (kg ash/kg DM).
 }
 \description{
-Computes the contribution of a single feed item to diet ash content by
-weighting feed ash content by its ration share.
+Computes the contribution of a single feed component to diet ash content by
+weighting feed ash content by its ration composition share.
 }
 \details{
 The ash contribution is defined as:

--- a/man/calc_diet_ash.Rd
+++ b/man/calc_diet_ash.Rd
@@ -7,22 +7,24 @@
 calc_diet_ash(feed_ration_fraction, feed_ash_content)
 }
 \arguments{
-\item{feed_ration_fraction}{Numeric proportion of a specific feed item in the total ration,
-expressed as its fraction of diet dry matter (fraction).}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
+total ration, expressed as its fraction of diet dry matter (fraction). Within
+each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_ash_content}{Numeric. Average ash content by feed item,
-calculated as a fraction of the dry matter intake (g ash/100g DM).}
+\item{feed_ash_content}{Numeric. Average ash content by feed item, calculated as
+a fraction of the dry matter intake (g ash/100g DM).}
 }
 \value{
-Numeric. Average ash content of feed, calculated as a fraction of
-the dry matter intake (kg ash/kg DM).
+Numeric. Average ash content contribution of the diet component,
+calculated as a fraction of the dry matter intake (kg ash/kg DM).
 }
 \description{
-Computes ash contribution from a ration share and ash content.
+Computes the contribution of a single feed item to diet ash content by
+weighting feed ash content by its ration share.
 }
 \details{
 The ash contribution is defined as:
 \deqn{diet\_ash = feed\_ration\_fraction \times feed\_ash\_content / 100}
 
-Ash content is expressed as a percentage; the result is a fraction.
+Ash content is expressed as a percentage (g/100g DM); the result is a fraction.
 }

--- a/man/calc_diet_digestibility.Rd
+++ b/man/calc_diet_digestibility.Rd
@@ -13,31 +13,49 @@ calc_diet_digestibility(
 )
 }
 \arguments{
-\item{species_short}{Character. Species short code. Supported values include
-ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}),
-chickens (\code{CHK}), and pigs (\code{PGS}).}
+\item{species_short}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+\item \code{CHK}: chickens
+}}
 
-\item{feed_ration_fraction}{Numeric. Ration share for the feed component (fraction).}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
+total ration, expressed as its fraction of diet dry matter (fraction). Within
+each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_digestibility_fraction_ruminant}{Numeric. Digestibility ratio for ruminants.}
+\item{feed_digestibility_fraction_ruminant}{Numeric. Digestibility of a feed
+item for ruminants, expressed as the ratio of digestible energy to gross energy
+content (fraction).}
 
-\item{feed_digestibility_fraction_pigs}{Numeric. Digestibility ratio for pigs.}
+\item{feed_digestibility_fraction_pigs}{Numeric. Digestibility of a feed item
+for pigs, expressed as the ratio of digestible energy to gross energy content
+(fraction).}
 
-\item{feed_digestibility_fraction_chicken}{Numeric. Digestibility ratio for chickens.}
+\item{feed_digestibility_fraction_chicken}{Numeric. Digestibility of a feed
+item for chickens, expressed as the ratio of metabolizable energy to gross
+energy content (fraction).}
 }
 \value{
-Numeric. Digestibility contribution for the ration component.
+Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction).
 }
 \description{
-Applies species-specific digestibility parameters to a ration share.
+Applies species-specific digestibility parameters to a ration share to compute
+the contribution of a single feed component to total diet digestibility.
 }
 \details{
 The digestibility contribution uses the animal-specific digestibility ratio:
 \itemize{
-\item Ruminants: \code{feed_ration_fraction * feed_digestibility_fraction_ruminant}
-\item Chickens: \code{feed_ration_fraction * feed_digestibility_fraction_chicken}
-\item Pigs: \code{feed_ration_fraction * feed_digestibility_fraction_pigs}
+\item Ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}):
+\code{feed_ration_fraction * feed_digestibility_fraction_ruminant}
+\item Chickens (\code{CHK}):
+\code{feed_ration_fraction * feed_digestibility_fraction_chicken}
+\item Pigs (\code{PGS}):
+\code{feed_ration_fraction * feed_digestibility_fraction_pigs}
 }
-
-This helper is vectorized over its inputs.
 }

--- a/man/calc_diet_digestibility.Rd
+++ b/man/calc_diet_digestibility.Rd
@@ -25,27 +25,27 @@ Supported values include:
 \item \code{CHK}: chickens
 }}
 
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
-total ration, expressed as its fraction of diet dry matter (fraction). Within
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the
+total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 each herd_id and cohort, proportions should sum to 1.}
 
 \item{feed_digestibility_fraction_ruminant}{Numeric. Digestibility of a feed
-item for ruminants, expressed as the ratio of digestible energy to gross energy
+component for ruminants, expressed as the ratio of digestible energy to gross energy
 content (fraction).}
 
-\item{feed_digestibility_fraction_pigs}{Numeric. Digestibility of a feed item
+\item{feed_digestibility_fraction_pigs}{Numeric. Digestibility of a feed component
 for pigs, expressed as the ratio of digestible energy to gross energy content
 (fraction).}
 
 \item{feed_digestibility_fraction_chicken}{Numeric. Digestibility of a feed
-item for chickens, expressed as the ratio of metabolizable energy to gross
+component for chickens, expressed as the ratio of metabolizable energy to gross
 energy content (fraction).}
 }
 \value{
-Numeric. Average digestibility of the the feed ration, expressed as ratio of digestible to gross energy content (fraction).
+Numeric. Contribution of the feed component to total diet digestibility (fraction).
 }
 \description{
-Applies species-specific digestibility parameters to a ration share to compute
+Applies species-specific digestibility parameters to a ration composition share to compute
 the contribution of a single feed component to total diet digestibility.
 }
 \details{

--- a/man/calc_diet_gross_energy.Rd
+++ b/man/calc_diet_gross_energy.Rd
@@ -7,21 +7,20 @@
 calc_diet_gross_energy(feed_ration_fraction, feed_gross_energy)
 }
 \arguments{
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
-total ration, expressed as its fraction of diet dry matter (fraction). Within
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the
+total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+\item{feed_gross_energy}{Numeric. Gross energy content of a feed component,
 representing the total chemical energy released upon complete combustion of
 the feed (MJ/kg DM).}
 }
 \value{
-Numeric. Average gross energy contribution of the diet component
-(MJ/kg DM).
+Numeric. Contribution of the feed component to total diet gross energy content (MJ/kg DM).
 }
 \description{
-Computes the contribution of a single feed item to diet gross energy by
-weighting feed gross energy by its ration share.
+Computes the contribution of a single feed component to diet gross energy content by
+weighting feed gross energy by its ration composition share.
 }
 \details{
 The gross energy contribution is defined as:

--- a/man/calc_diet_gross_energy.Rd
+++ b/man/calc_diet_gross_energy.Rd
@@ -7,19 +7,23 @@
 calc_diet_gross_energy(feed_ration_fraction, feed_gross_energy)
 }
 \arguments{
-\item{feed_ration_fraction}{Numeric. Ration share for the feed component (fraction).}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
+total ration, expressed as its fraction of diet dry matter (fraction). Within
+each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_gross_energy}{Numeric. Gross energy content (MJ/kg DM).}
+\item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+representing the total chemical energy released upon complete combustion of
+the feed (MJ/kg DM).}
 }
 \value{
-Numeric. Gross energy contribution for the ration component.
+Numeric. Average gross energy contribution of the diet component
+(MJ/kg DM).
 }
 \description{
-Computes gross energy contribution from a ration share and gross energy input.
+Computes the contribution of a single feed item to diet gross energy by
+weighting feed gross energy by its ration share.
 }
 \details{
 The gross energy contribution is defined as:
 \deqn{diet\_gross\_energy = feed\_ration\_fraction \times feed\_gross\_energy}
-
-This helper is vectorized over its inputs.
 }

--- a/man/calc_diet_metabolizable_energy.Rd
+++ b/man/calc_diet_metabolizable_energy.Rd
@@ -13,31 +13,51 @@ calc_diet_metabolizable_energy(
 )
 }
 \arguments{
-\item{species_short}{Character. Species short code. Supported values include
-ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}),
-chickens (\code{CHK}), and pigs (\code{PGS}).}
+\item{species_short}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+\item \code{CHK}: chickens
+}}
 
-\item{feed_ration_fraction}{Numeric. Ration share for the feed component (fraction).}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
+total ration, expressed as its fraction of diet dry matter (fraction). Within
+each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy for ruminants.}
+\item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy content
+of a feed item for ruminants, representing digestible energy minus energy
+losses in urine and gaseous products of digestion (MJ/kg DM).}
 
-\item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy for pigs.}
+\item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy content of a
+feed item for pigs, representing digestible energy minus energy losses in
+urine and gaseous products of digestion (MJ/kg DM).}
 
-\item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy for chickens.}
+\item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy content
+of a feed item for chickens, representing digestible energy minus energy
+losses in urine and gaseous products of digestion (MJ/kg DM).}
 }
 \value{
-Numeric. Metabolizable energy contribution for the ration component.
+Numeric. Metabolizable energy contribution of the feed component to the
+total diet metabolizable energy (MJ/kg DM).
 }
 \description{
-Applies species-specific metabolizable energy parameters to a ration share.
+Applies species-specific metabolizable energy parameters to a ration share to
+compute the contribution of a single feed component to total diet metabolizable
+energy.
 }
 \details{
 The metabolizable energy contribution uses the animal-specific parameter:
 \itemize{
-\item Ruminants: \code{feed_ration_fraction * feed_metabolizable_energy_ruminant}
-\item Chickens: \code{feed_ration_fraction * feed_metabolizable_energy_chicken}
-\item Pigs: \code{feed_ration_fraction * feed_metabolizable_energy_pigs}
+\item Ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}):
+\code{feed_ration_fraction * feed_metabolizable_energy_ruminant}
+\item Chickens (\code{CHK}):
+\code{feed_ration_fraction * feed_metabolizable_energy_chicken}
+\item Pigs (\code{PGS}):
+\code{feed_ration_fraction * feed_metabolizable_energy_pigs}
 }
-
-This helper is vectorized over its inputs.
 }

--- a/man/calc_diet_metabolizable_energy.Rd
+++ b/man/calc_diet_metabolizable_energy.Rd
@@ -25,30 +25,29 @@ Supported values include:
 \item \code{CHK}: chickens
 }}
 
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
-total ration, expressed as its fraction of diet dry matter (fraction). Within
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the
+total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 each herd_id and cohort, proportions should sum to 1.}
 
 \item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy content
-of a feed item for ruminants, representing digestible energy minus energy
+of a feed component for ruminants, representing digestible energy minus energy
 losses in urine and gaseous products of digestion (MJ/kg DM).}
 
 \item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy content of a
-feed item for pigs, representing digestible energy minus energy losses in
+feed component for pigs, representing digestible energy minus energy losses in
 urine and gaseous products of digestion (MJ/kg DM).}
 
 \item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy content
-of a feed item for chickens, representing digestible energy minus energy
-losses in urine and gaseous products of digestion (MJ/kg DM).}
+of a feed component for chickens, representing digestible energy minus energy
+losses in uric acid and gaseous products of digestion (MJ/kg DM).}
 }
 \value{
-Numeric. Metabolizable energy contribution of the feed component to the
-total diet metabolizable energy (MJ/kg DM).
+Numeric. Contribution of the feed component to total diet metabolizable energy content (MJ/kg DM).
 }
 \description{
-Applies species-specific metabolizable energy parameters to a ration share to
+Applies species-specific metabolizable energy parameters to a ration composition share to
 compute the contribution of a single feed component to total diet metabolizable
-energy.
+energy content.
 }
 \details{
 The metabolizable energy contribution uses the animal-specific parameter:

--- a/man/calc_diet_nitrogen_content.Rd
+++ b/man/calc_diet_nitrogen_content.Rd
@@ -7,15 +7,18 @@
 calc_diet_nitrogen_content(feed_ration_fraction, feed_nitrogen_content)
 }
 \arguments{
-\item{feed_ration_fraction}{Numeric. Ration share for the feed component (fraction).}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
+total ration, expressed as its fraction of diet dry matter (fraction). Within
+each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_nitrogen_content}{Numeric. Nitrogen content (kg N/kg DM).}
+\item{feed_nitrogen_content}{Numeric. Nitrogen content a feed item (kg N/kg DM).}
 }
 \value{
-Numeric. Nitrogen contribution for the ration component.
+Numeric. Average nitrogen content of diet (kg N/kg DM).
 }
 \description{
-Computes nitrogen contribution from a ration share and nitrogen content.
+Computes the contribution of a single feed item to diet nitrogen content by
+weighting feed nitrogen content by its ration share.
 }
 \details{
 The nitrogen contribution is defined as:

--- a/man/calc_diet_nitrogen_content.Rd
+++ b/man/calc_diet_nitrogen_content.Rd
@@ -7,22 +7,20 @@
 calc_diet_nitrogen_content(feed_ration_fraction, feed_nitrogen_content)
 }
 \arguments{
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
-total ration, expressed as its fraction of diet dry matter (fraction). Within
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the
+total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 each herd_id and cohort, proportions should sum to 1.}
 
-\item{feed_nitrogen_content}{Numeric. Nitrogen content a feed item (kg N/kg DM).}
+\item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed component (kg N/kg DM).}
 }
 \value{
-Numeric. Average nitrogen content of diet (kg N/kg DM).
+Numeric. Contribution of the feed component to total diet nitrogen content (kg N/kg DM).
 }
 \description{
-Computes the contribution of a single feed item to diet nitrogen content by
-weighting feed nitrogen content by its ration share.
+Computes the contribution of a single feed component to diet nitrogen content by
+weighting feed nitrogen content by its ration composition share.
 }
 \details{
 The nitrogen contribution is defined as:
 \deqn{diet\_nitrogen = feed\_ration\_fraction \times feed\_nitrogen\_content}
-
-This helper is vectorized over its inputs.
 }

--- a/man/calc_feed_digestibility_fraction.Rd
+++ b/man/calc_feed_digestibility_fraction.Rd
@@ -12,31 +12,50 @@ calc_feed_digestibility_fraction(
 )
 }
 \arguments{
-\item{feed_digestible_energy_ruminant}{Numeric. Digestible energy for ruminants
-(same units as \code{feed_gross_energy}).}
+\item{feed_digestible_energy_ruminant}{Numeric. Digestible energy content of a
+feed item for ruminants, representing the energy absorbed by the animal after
+fecal losses (MJ/kg DM).}
 
-\item{feed_digestible_energy_pigs}{Numeric. Digestible energy for pigs
-(same units as \code{feed_gross_energy}).}
+\item{feed_digestible_energy_pigs}{Numeric. Digestible energy content of a feed
+item for pigs, representing the energy absorbed by the animal after fecal
+losses (MJ/kg DM).}
 
-\item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy for chickens
-(same units as \code{feed_gross_energy}).}
+\item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy content
+of a feed item for chickens, representing digestible energy minus energy
+losses in urine and gaseous products of digestion (MJ/kg DM).}
 
-\item{feed_gross_energy}{Numeric. Gross energy (same units as
-\code{feed_digestible_energy_ruminant}, \code{feed_digestible_energy_pigs},
-and \code{feed_metabolizable_energy_chicken}).}
+\item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+representing the total chemical energy released upon complete combustion of
+the feed (MJ/kg DM).}
 }
 \value{
-List. Digestibility fractions (unitless) with elements:
-\code{feed_digestibility_fraction_ruminant}, \code{feed_digestibility_fraction_pigs},
-\code{feed_digestibility_fraction_chicken}.
+List with elements:
+\describe{
+\item{feed_digestibility_fraction_ruminant}{
+Numeric. Digestibility of a feed item for ruminants, expressed as the ratio
+of digestible energy to gross energy content (fraction).
+}
+\item{feed_digestibility_fraction_pigs}{
+Numeric. Digestibility of a feed item for pigs, expressed as the ratio of
+digestible energy to gross energy content (fraction).
+}
+\item{feed_digestibility_fraction_chicken}{
+Numeric. Digestibility of a feed item for chickens, expressed as the ratio
+of metabolizable energy to gross energy content (fraction).
+}
+}
 }
 \description{
-Computes digestibility as the ratio of digestible or metabolizable energy
-to gross energy.
+Computes species-specific feed digestibility fractions by feed item.
 }
 \details{
-The digestibility ratio is defined as:
-\deqn{feed\_digestibility\_fraction = feed\_digestible\_energy / feed\_gross\_energy}
+Digestibility is computed as the ratio of usable energy to gross energy:
+\deqn{feed\_digestibility\_fraction = usable\_energy / feed\_gross\_energy}
 
-This helper is vectorized over its inputs.
+For ruminants and pigs, usable energy is represented by \code{digestible_energy} (DE),
+which accounts for fecal energy losses. For chickens, \code{metabolizable_energy}
+(ME) is used instead of \code{digestible_energy} because urinary and fecal
+excretions are voided together, making fecal energy losses difficult to measure
+separately. \code{metabolizable_energy} therefore provides a more appropriate and
+standard measure of usable dietary energy in poultry nutrition.
 }

--- a/man/calc_feed_digestibility_fraction.Rd
+++ b/man/calc_feed_digestibility_fraction.Rd
@@ -13,18 +13,18 @@ calc_feed_digestibility_fraction(
 }
 \arguments{
 \item{feed_digestible_energy_ruminant}{Numeric. Digestible energy content of a
-feed item for ruminants, representing the energy absorbed by the animal after
+feed component for ruminants, representing the energy absorbed by the animal after
 fecal losses (MJ/kg DM).}
 
 \item{feed_digestible_energy_pigs}{Numeric. Digestible energy content of a feed
-item for pigs, representing the energy absorbed by the animal after fecal
+component for pigs, representing the energy absorbed by the animal after fecal
 losses (MJ/kg DM).}
 
 \item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy content
-of a feed item for chickens, representing digestible energy minus energy
-losses in urine and gaseous products of digestion (MJ/kg DM).}
+of a feed component for chickens, representing digestible energy minus energy
+losses in uric acid and gaseous products of digestion (MJ/kg DM).}
 
-\item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+\item{feed_gross_energy}{Numeric. Gross energy content of a feed component,
 representing the total chemical energy released upon complete combustion of
 the feed (MJ/kg DM).}
 }
@@ -32,21 +32,21 @@ the feed (MJ/kg DM).}
 List with elements:
 \describe{
 \item{feed_digestibility_fraction_ruminant}{
-Numeric. Digestibility of a feed item for ruminants, expressed as the ratio
+Numeric. Digestibility of a feed component for ruminants, expressed as the ratio
 of digestible energy to gross energy content (fraction).
 }
 \item{feed_digestibility_fraction_pigs}{
-Numeric. Digestibility of a feed item for pigs, expressed as the ratio of
+Numeric. Digestibility of a feed component for pigs, expressed as the ratio of
 digestible energy to gross energy content (fraction).
 }
 \item{feed_digestibility_fraction_chicken}{
-Numeric. Digestibility of a feed item for chickens, expressed as the ratio
+Numeric. Digestibility of a feed component for chickens, expressed as the ratio
 of metabolizable energy to gross energy content (fraction).
 }
 }
 }
 \description{
-Computes species-specific feed digestibility fractions by feed item.
+Computes species-specific feed digestibility fractions by feed component.
 }
 \details{
 Digestibility is computed as the ratio of usable energy to gross energy:
@@ -54,7 +54,7 @@ Digestibility is computed as the ratio of usable energy to gross energy:
 
 For ruminants and pigs, usable energy is represented by \code{digestible_energy} (DE),
 which accounts for fecal energy losses. For chickens, \code{metabolizable_energy}
-(ME) is used instead of \code{digestible_energy} because urinary and fecal
+(ME) is used instead of \code{digestible_energy} because urinary losses (excreted as uric acid) and fecal
 excretions are voided together, making fecal energy losses difficult to measure
 separately. \code{metabolizable_energy} therefore provides a more appropriate and
 standard measure of usable dietary energy in poultry nutrition.

--- a/man/calc_urinary_energy_fraction.Rd
+++ b/man/calc_urinary_energy_fraction.Rd
@@ -25,8 +25,8 @@ Supported values include:
 \item \code{CHK}: chickens
 }}
 
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
-total ration, expressed as its fraction of diet dry matter (fraction). Within
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the
+total ration, expressed as its fraction of diet dry matter intake (fraction). Within
 each herd_id and cohort, proportions should sum to 1.}
 
 \item{feed_urinary_energy_ruminant}{Numeric. Fraction of feed's gross energy that
@@ -36,14 +36,14 @@ is excreted in urine for ruminants (fraction).}
 is excreted in urine for pigs (fraction).}
 
 \item{feed_urinary_energy_chicken}{Numeric. Fraction of feed's gross energy that
-is excreted in urine for chickens (fraction). Default = 0.}
+is excreted in uric acid for chickens (fraction). Default = 0.}
 }
 \value{
-Numeric. Fraction of feed's gross energy that is excreted in urine
-(fraction).
+Numeric. Contribution of the feed component to the fraction of total diet
+gross energy that is excreted in urine (fraction).
 }
 \description{
-Applies species-specific urinary energy fractions to a ration share to compute
+Applies species-specific urinary energy fractions to a ration composition share to compute
 the contribution of a feed component to urinary energy losses.
 }
 \details{

--- a/man/calc_urinary_energy_fraction.Rd
+++ b/man/calc_urinary_energy_fraction.Rd
@@ -13,12 +13,21 @@ calc_urinary_energy_fraction(
 )
 }
 \arguments{
-\item{species_short}{Character. Species short code. Supported values include
-ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}),
-chickens (\code{CHK}), and pigs (\code{PGS}).}
+\item{species_short}{Character. Code identifying the livestock species.
+Supported values include:
+\itemize{
+\item \code{PGS}: pigs
+\item \code{CML}: camels
+\item \code{CTL}: cattle
+\item \code{BFL}: buffalo
+\item \code{SHP}: sheep
+\item \code{GTS}: goats
+\item \code{CHK}: chickens
+}}
 
-\item{feed_ration_fraction}{Numeric proportion of a specific feed item in the total ration,
-expressed as its fraction of diet dry matter (fraction)}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the
+total ration, expressed as its fraction of diet dry matter (fraction). Within
+each herd_id and cohort, proportions should sum to 1.}
 
 \item{feed_urinary_energy_ruminant}{Numeric. Fraction of feed's gross energy that
 is excreted in urine for ruminants (fraction).}
@@ -27,19 +36,29 @@ is excreted in urine for ruminants (fraction).}
 is excreted in urine for pigs (fraction).}
 
 \item{feed_urinary_energy_chicken}{Numeric. Fraction of feed's gross energy that
-is excreted in urine for chickens (fraction). Default to 0.}
+is excreted in urine for chickens (fraction). Default = 0.}
 }
 \value{
-Numeric. Fraction of feed's gross energy that is excreted in urine (fraction).
+Numeric. Fraction of feed's gross energy that is excreted in urine
+(fraction).
 }
 \description{
-Applies species-specific urinary energy parameters to a ration share.
+Applies species-specific urinary energy fractions to a ration share to compute
+the contribution of a feed component to urinary energy losses.
 }
 \details{
 The urinary energy fraction contribution uses the animal-specific parameter:
 \itemize{
-\item Ruminants: \code{feed_ration_fraction * feed_urinary_energy_ruminant}
-\item Chickens: \code{feed_ration_fraction * feed_urinary_energy_chicken}
-\item Pigs: \code{feed_ration_fraction * feed_urinary_energy_pigs}
+\item Ruminants (\code{CTL}, \code{BFL}, \code{CML}, \code{SHP}, \code{GTS}):
+\code{feed_ration_fraction * feed_urinary_energy_ruminant}
+\item Chickens (\code{CHK}):
+\code{feed_ration_fraction * feed_urinary_energy_chicken}
+\item Pigs (\code{PGS}):
+\code{feed_ration_fraction * feed_urinary_energy_pigs}
 }
+
+For chickens, \code{feed_urinary_energy_chicken} defaults to 0 because urinary
+energy losses are accounted for within \code{metabolizable_energy} in poultry
+nutrition (urine and feces are excreted together), and are therefore not modeled
+as a separate fraction of gross energy.
 }

--- a/man/run_feed_rations.Rd
+++ b/man/run_feed_rations.Rd
@@ -11,7 +11,7 @@ run_feed_rations(
 )
 }
 \arguments{
-\item{rations_share}{data.table. Cohort-level feed ration shares with the
+\item{rations_share}{data.table. Cohort-level feed ration composition shares with the
 following minimum data requirement:
 \describe{
 \item{herd_id}{Character. Unique identifier for the herd, repeated for each
@@ -41,51 +41,51 @@ of the animals. Supported values include:
 \item \code{MJ}: juvenile males (from birth to weaning)
 }
 }
-\item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
-\item{feed_name}{Character. Feed item name (optional, for readability and
-reporting). If provided, should be consistent with \code{feed_id}.}
-\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the total ration, expressed as its fraction of diet dry matter (fraction).
+\item{feed_id}{Character. Unique identifier for the feed component, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+\item{feed_name}{Character. feed component name (optional, for readability and
+reporting). If provided, it should uniquely identify the same feed component as \code{feed_id}.}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed component in the total ration, expressed as its fraction of diet dry matter intake (fraction).
 Within each herd_id and cohort, proportions should sum to 1.}
 }}
 
-\item{feed_params}{data.table. Feed nutrient parameters with the following
+\item{feed_params}{data.table. Feed nutritional parameters with the following
 minimum data requirement:
 \describe{
-\item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
-\item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+\item{feed_id}{Character. Unique identifier for the feed component, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+\item{feed_gross_energy}{Numeric. Gross energy content of a feed component,
 representing the total chemical energy released upon complete combustion of
 the feed (MJ/kg DM).}
 \item{feed_digestible_energy_ruminant}{Numeric. Digestible energy content of
-a feed item for ruminants, representing the energy absorbed by the animal
+a feed component for ruminants, representing the energy absorbed by the animal
 after fecal losses (MJ/kg DM).}
 \item{feed_digestible_energy_pigs}{Numeric. Digestible energy content of a
-feed item for pigs, representing the energy absorbed by the animal after
+feed component for pigs, representing the energy absorbed by the animal after
 fecal losses (MJ/kg DM).}
 \item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy
-content of a feed item for ruminants, representing digestible energy minus
+content of a feed component for ruminants, representing digestible energy minus
 energy losses in urine and gaseous products of digestion (MJ/kg DM).}
 \item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy content
-of a feed item for pigs, representing digestible energy minus energy losses
+of a feed component for pigs, representing digestible energy minus energy losses
 in urine and gaseous products of digestion (MJ/kg DM).}
 \item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy
-content of a feed item for chickens, representing digestible energy minus
-energy losses in urine and gaseous products of digestion (MJ/kg DM).}
-\item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed item
+content of a feed component for chickens, representing digestible energy minus
+energy losses in uric acid and gaseous products of digestion (MJ/kg DM).}
+\item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed component
 (kg N/kg DM).}
 \item{feed_urinary_energy_ruminant}{Numeric. Fraction of feed's gross energy
 that is excreted in urine for ruminants (fraction).}
 \item{feed_urinary_energy_pigs}{Numeric. Fraction of feed's gross energy
 that is excreted in urine for pigs (fraction).}
-\item{feed_ash_content}{Numeric. Average ash content by feed item, calculated
+\item{feed_ash_content}{Numeric. Average ash content by feed component, calculated
 as a fraction of the dry matter intake (g ash/100g DM).}
-\item{category}{Character. Feed category (optional). If provided, should be
-consistent with \code{feed_id} for a coherent result.}
-\item{feed_name}{Character. Feed item name (optional, for readability and
-reporting). If provided, should be consistent with \code{feed_id}.}
+\item{category}{Character. Feed category (optional). If provided, it should be
+used consistently  with \code{feed_id}, for a coherent result.}
+\item{feed_name}{Character. feed component name (optional, for readability and
+reporting). If provided, it should uniquely identify the same feed component as \code{feed_id}.}
 }}
 }
 \value{
-data.table. Cohort-level diet metrics summarized by \code{herd_id},
+data.table. Cohort-level nutritional metrics summarized by \code{herd_id},
 \code{animal}, and \code{cohort_short} with the following columns:
 \describe{
 \item{diet_gross_energy}{Numeric. Average gross energy content of the diet
@@ -103,21 +103,21 @@ of the dry matter intake (kg ash/kg DM).}
 }
 }
 \description{
-Compute cohort-level diet composition metrics (gross and metabolizable energy
+Computes cohort-level diet nutritional metrics (gross and metabolizable energy
 content, digestibility, nitrogen content, urinary energy losses, and ash
-content) from cohort-level feed ration shares and feed item nutrient
+content) from cohort-level feed ration composition shares and feed component nutrient
 parameters.
 }
 \details{
 This function joins \code{rations_share} with \code{feed_params} by \code{feed_id},
-maps \code{animal} to a species short code, and computes ration-weighted diet
+maps \code{animal} to a species short code, and computes ration-weighted nutritional
 metrics by cohort.
 
 The following calculation sequence is applied:
 \enumerate{
 \item Species-specific digestibility ratios are computed from energy parameters
 and \code{feed_gross_energy} using \code{\link{calc_feed_digestibility_fraction}}.
-\item Feed-level contributions are computed as ration-weighted values:
+\item Contributions of each feed component are computed as ration-weighted values:
 \itemize{
 \item gross energy using \code{\link{calc_diet_gross_energy}}
 \item nitrogen using \code{\link{calc_diet_nitrogen_content}}
@@ -126,8 +126,8 @@ and \code{feed_gross_energy} using \code{\link{calc_feed_digestibility_fraction}
 \item urinary energy fraction using \code{\link{calc_urinary_energy_fraction}}
 \item ash using \code{\link{calc_diet_ash}}
 }
-\item Cohort-level diet metrics are obtained by summing contributions across
-feed items within each \code{herd_id}, \code{animal}, and \code{cohort_short}.
+\item Cohort-level nutritional metrics are obtained for the whole feed ration by summing contributions across
+feed components within each \code{herd_id}, \code{animal}, and \code{cohort_short}.
 }
 }
 \examples{

--- a/man/run_feed_rations.Rd
+++ b/man/run_feed_rations.Rd
@@ -11,37 +11,114 @@ run_feed_rations(
 )
 }
 \arguments{
-\item{rations_share}{A data.table containing feed shares per cohort. Must include:
+\item{rations_share}{data.table. Cohort-level feed ration shares with the
+following minimum data requirement:
+\describe{
+\item{herd_id}{Character. Unique identifier for the herd, repeated for each
+cohort belonging to the same herd.}
+\item{animal}{Character. Livestock category name used to map to a species
+short code via internal lookup (e.g., for applying species-specific energy
+parameters).}
+\item{cohort_short}{
+Character. Sex- and age-specific cohort code describing the production stage
+of the animals. Supported values include:
 \itemize{
-\item \code{herd_id}, \code{animal}, \code{feed_name}, \code{feed_id}, \code{cohort_short}, and
-\code{feed_ration_fraction}.
-\item Note that \code{feed_name} is optional but should be consistent with \code{feed_id}
-for a coherent result.
+\item \code{FA}: adult females (from age at first parturition)
+\item \code{FS}: sub-adult females (from weaning to age at first parturition)
+\item \code{FJ}: juvenile females (from birth to weaning)
+\item \code{MA}: adult males (from age at first breeding)
+\item \code{MS}: sub-adult males (from weaning to age at first breeding)
+\item \code{MJ}: juvenile males (from birth to weaning)
+}
+}
+\item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+\item{feed_name}{Character. Feed item name (optional, for readability and
+reporting). If provided, should be consistent with \code{feed_id}.}
+\item{feed_ration_fraction}{Numeric. Proportion of a specific feed item in the total ration, expressed as its fraction of diet dry matter (fraction).
+Within each herd_id and cohort, proportions should sum to 1.}
 }}
 
-\item{feed_params}{A data.table of nutrient parameters. Must include:
-\itemize{
-\item \code{feed_id}, \code{feed_gross_energy},
-\code{feed_digestible_energy_ruminant}, \code{feed_digestible_energy_pigs},
-\code{feed_metabolizable_energy_ruminant}, \code{feed_metabolizable_energy_pigs},
-\code{feed_metabolizable_energy_chicken}, \code{feed_nitrogen_content},
-\code{feed_urinary_energy_ruminant}, \code{feed_urinary_energy_pigs},
-\code{feed_ash_content}.
-\item Note that \code{category} and \code{feed_name} are optional but should be consistent with \code{feed_id}
-for a coherent result.
+\item{feed_params}{data.table. Feed nutrient parameters with the following
+minimum data requirement:
+\describe{
+\item{feed_id}{Character. Unique identifier for the feed item, used to join feed ration data (\code{rations_share}) with feed nutritional parameters table (\code{feed_params}). Must be unique.}
+\item{feed_gross_energy}{Numeric. Gross energy content of a feed item,
+representing the total chemical energy released upon complete combustion of
+the feed (MJ/kg DM).}
+\item{feed_digestible_energy_ruminant}{Numeric. Digestible energy content of
+a feed item for ruminants, representing the energy absorbed by the animal
+after fecal losses (MJ/kg DM).}
+\item{feed_digestible_energy_pigs}{Numeric. Digestible energy content of a
+feed item for pigs, representing the energy absorbed by the animal after
+fecal losses (MJ/kg DM).}
+\item{feed_metabolizable_energy_ruminant}{Numeric. Metabolizable energy
+content of a feed item for ruminants, representing digestible energy minus
+energy losses in urine and gaseous products of digestion (MJ/kg DM).}
+\item{feed_metabolizable_energy_pigs}{Numeric. Metabolizable energy content
+of a feed item for pigs, representing digestible energy minus energy losses
+in urine and gaseous products of digestion (MJ/kg DM).}
+\item{feed_metabolizable_energy_chicken}{Numeric. Metabolizable energy
+content of a feed item for chickens, representing digestible energy minus
+energy losses in urine and gaseous products of digestion (MJ/kg DM).}
+\item{feed_nitrogen_content}{Numeric. Nitrogen content of a feed item
+(kg N/kg DM).}
+\item{feed_urinary_energy_ruminant}{Numeric. Fraction of feed's gross energy
+that is excreted in urine for ruminants (fraction).}
+\item{feed_urinary_energy_pigs}{Numeric. Fraction of feed's gross energy
+that is excreted in urine for pigs (fraction).}
+\item{feed_ash_content}{Numeric. Average ash content by feed item, calculated
+as a fraction of the dry matter intake (g ash/100g DM).}
+\item{category}{Character. Feed category (optional). If provided, should be
+consistent with \code{feed_id} for a coherent result.}
+\item{feed_name}{Character. Feed item name (optional, for readability and
+reporting). If provided, should be consistent with \code{feed_id}.}
 }}
 }
 \value{
-A data.table summarized by \code{herd_id}, \code{animal}, and \code{cohort_short} with:
-\itemize{
-\item \code{diet_gross_energy}, \code{diet_metabolizable_energy},
-\code{diet_nitrogen}, \code{diet_digestibility_fraction},
-\code{urinary_energy_fraction}, \code{diet_ash}
+data.table. Cohort-level diet metrics summarized by \code{herd_id},
+\code{animal}, and \code{cohort_short} with the following columns:
+\describe{
+\item{diet_gross_energy}{Numeric. Average gross energy content of the diet
+(MJ/kg DM).}
+\item{diet_metabolizable_energy}{Numeric. Average metabolizable energy
+content of the diet (MJ/kg DM).}
+\item{diet_nitrogen}{Numeric. Average nitrogen content of diet (kg N/kg DM).}
+\item{diet_digestibility_fraction}{Numeric. Average digestibility of the feed
+ration, expressed as ratio of digestible (or metabolizable, for poultry) to
+gross energy content (fraction).}
+\item{urinary_energy_fraction}{Numeric. Fraction of feed's gross energy that
+is excreted in urine (fraction).}
+\item{diet_ash}{Numeric. Average ash content of feed, calculated as a fraction
+of the dry matter intake (kg ash/kg DM).}
 }
 }
 \description{
-Computes cohort-level dietary energy, digestibility, and nitrogen intake
-from feed rations and nutritional parameters. Assumes inputs are pre-cleaned.
+Compute cohort-level diet composition metrics (gross and metabolizable energy
+content, digestibility, nitrogen content, urinary energy losses, and ash
+content) from cohort-level feed ration shares and feed item nutrient
+parameters.
+}
+\details{
+This function joins \code{rations_share} with \code{feed_params} by \code{feed_id},
+maps \code{animal} to a species short code, and computes ration-weighted diet
+metrics by cohort.
+
+The following calculation sequence is applied:
+\enumerate{
+\item Species-specific digestibility ratios are computed from energy parameters
+and \code{feed_gross_energy} using \code{\link{calc_feed_digestibility_fraction}}.
+\item Feed-level contributions are computed as ration-weighted values:
+\itemize{
+\item gross energy using \code{\link{calc_diet_gross_energy}}
+\item nitrogen using \code{\link{calc_diet_nitrogen_content}}
+\item digestibility using \code{\link{calc_diet_digestibility}}
+\item metabolizable energy using \code{\link{calc_diet_metabolizable_energy}}
+\item urinary energy fraction using \code{\link{calc_urinary_energy_fraction}}
+\item ash using \code{\link{calc_diet_ash}}
+}
+\item Cohort-level diet metrics are obtained by summing contributions across
+feed items within each \code{herd_id}, \code{animal}, and \code{cohort_short}.
+}
 }
 \examples{
 \dontrun{
@@ -56,4 +133,13 @@ rations_share <- data.table::fread(
 
 result <- run_feed_rations(rations_share, feed_params)
 }
+}
+\seealso{
+\code{\link{calc_feed_digestibility_fraction}},
+\code{\link{calc_diet_gross_energy}},
+\code{\link{calc_diet_nitrogen_content}},
+\code{\link{calc_diet_digestibility}},
+\code{\link{calc_diet_metabolizable_energy}},
+\code{\link{calc_urinary_energy_fraction}},
+\code{\link{calc_diet_ash}}
 }

--- a/man/run_feed_rations.Rd
+++ b/man/run_feed_rations.Rd
@@ -4,11 +4,7 @@
 \alias{run_feed_rations}
 \title{Calculate Feed Intake Metrics}
 \usage{
-run_feed_rations(
-  rations_share,
-  feed_params = data.table::fread(system.file("extdata/Parameters/feed/feed_params.csv",
-    package = "gleam"))
-)
+run_feed_rations(rations_share, feed_params)
 }
 \arguments{
 \item{rations_share}{data.table. Cohort-level feed ration composition shares with the

--- a/man/run_feed_rations.Rd
+++ b/man/run_feed_rations.Rd
@@ -16,9 +16,19 @@ following minimum data requirement:
 \describe{
 \item{herd_id}{Character. Unique identifier for the herd, repeated for each
 cohort belonging to the same herd.}
-\item{animal}{Character. Livestock category name used to map to a species
-short code via internal lookup (e.g., for applying species-specific energy
-parameters).}
+\item{animal}{
+Character. Livestock category name used to map to a species short code via an
+internal lookup table. Supported values include:
+\itemize{
+\item \code{Cattle}
+\item \code{Buffalo}
+\item \code{Sheep}
+\item \code{Goats}
+\item \code{Chicken}
+\item \code{Pigs}
+\item \code{Camels}
+}
+}
 \item{cohort_short}{
 Character. Sex- and age-specific cohort code describing the production stage
 of the animals. Supported values include:


### PR DESCRIPTION
This PR contains unique updates to the documentation of the feed module (core + run).

Before moving to the next step (which is the review from @tempiog), clarification is required from @ahmedjoubest on the following (apologies, we missed this during the review of the dedicated PR):

- `species_short`: currently used in the scientific functions 
- `animal`: currently used in the input tables

   - _Shouldn't `animal` be renamed as `species`, to keep the logic consistent, as they refer to the same information of `species_short` just in short vs extended versions?_

   - As a more general consideration (**please ignore it for now due to time constraints**): as discussed in previous meetings, extended species names can be more prone to spelling variations and inconsistencies, especially for non-native English users. This could have some implications for usability.