### PR TITLE
[OP#311] Revision of variable definitions and documentation - Herd module

### DIFF
--- a/R/herd_simulation_core_model.R
+++ b/R/herd_simulation_core_model.R
@@ -2,14 +2,14 @@
 #'
 #' Calculates the daily number of male and female offspring produced per adult female.
 #'
-#' @param parturition_rate Numeric. Parturition rate (probability of an adult female to give birth).
-#' @param litter_size Numeric. Prolificacy rate (mean number of offspring per parturition).
-#' @param birth_fraction_female Numeric. Female birth ratio (probability that an offspring is female).
+#' @param parturition_rate Numeric. Average annual number of parturitions per female animal (# parturitions/adult female/year). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.
+#' @param litter_size Numeric. Average number of offspring born per parturition (# offsprings/parturition). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.
+#' @param birth_fraction_female Numeric. Female birth fraction, defined as the probability that a newborn offspring is female (fraction). Can be calculated  as the number of female offspring born divided by the total number of offspring born.
 #'
 #' @return A named list with two elements:
 #' \describe{
-#'   \item{fecundity_female}{Daily number of female offspring per adult female.}
-#'   \item{fecundity_male}{Daily number of male offspring per adult female.}
+#'   \item{fecundity_female}{Numeric. Daily number of female offspring per adult female (# offspring/day)}
+#'   \item{fecundity_male}{Numeric. Daily number of male offspring per adult female? (# offspring/day)}
 #' }
 #' @examples
 #' compute_fecundity_rates(parturition_rate = 0.8, litter_size = 2, birth_fraction_female = 0.5)
@@ -37,20 +37,25 @@ compute_fecundity_rates <- function(
 #' Compute Transition Probabilities for Sex-Age Classes
 #'
 #' Calculates hazard rates and daily transition probabilities (death, offtake, survival, and growth)
-#' across 10 cohorts derived from 6 sex-age classes.
+#' across different sex-age cohorts. Converts annual inputs to daily hazards, then derives daily probabilities 
+#' from those hazards.
 #'
-#' @param cohort_duration_days Numeric vector of length 6. Duration (in days) of each sex-age class.
-#' @param offtake_rate Numeric vector of length 6. Annual offtake rate for each sex-age class.
-#' @param death_rate Numeric vector of length 6. Annual death rate for each sex-age class.
+#' @param cohort_duration_days Numeric vector of length 6. Amount of time that each animal spends in a specific cohort (days).
+#' @param offtake_rate Numeric vector of length 6. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).
+#' @param death_rate Numeric vector of length 6. Fraction of deaths in a herd over a year for each sex-age cohort (fraction)
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{hazard_death}{Instantaneous mortality hazard rate for 6 sex-age classes.}
-#'   \item{hazard_offtake}{Instantaneous offtake hazard rate for 6 sex-age classes.}
-#'   \item{probability_death}{Daily death probability for 10 cohorts.}
-#'   \item{probability_offtake}{Daily offtake probability for 10 cohorts.}
-#'   \item{probability_survival}{Daily survival probability for 10 cohorts.}
-#'   \item{probability_growth}{Probability of growing into the next age class for 10 cohorts.}
+#'   \item{hazard_death}{Numeric vector of length 6. Instantaneous mortality hazard rate for the 6 sex–age cohorts. Represents the  risk of death per unit time (day⁻¹) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{hazard_offtake}{Numeric vector of length 6. Instantaneous offtake hazard rate for the 6 sex-age cohorts. Represents the risk to leave the herd through planned removals per unit of time (day⁻¹) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{probability_death}{Named numeric vector of length 10. Probability of animal dying within the model time interval for 10 cohorts (fraction). 
+#'   (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+#'   \item{probability_offtake}{Named numeric vector of length 10. Probability that an animal will be removed from the herd within the model time interval for 10 cohorts (fraction).  
+#'   (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+#'   \item{probability_survival}{Named numeric vector of length 10. Probability that an animal remains alive in the herd within the model time interval for 10 cohorts (fraction). 
+#'   (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+#'   \item{probability_growth}{Named numeric vector of length 10. Probability of growing into the next age class for 10 cohorts (fraction) 
+#'   (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
 #' }
 #'
 #' @export
@@ -191,30 +196,35 @@ compute_transition_probabilities <- function(
 
 #' Simulate Steady-State Population Structure
 #'
-#' Simulates population dynamics over time until a steady-state is reached. Tracks age-class structure and
-#' population growth based on survival, offtake, and fecundity parameters.
+#' 
+#'Simulates population dynamics over time until a steady state is reached.
+#'The steady state is defined as a constant sex–age cohort structure over time,
+#'with population size potentially growing or declining at a constant rate.
+#'Tracks sex–age cohort structure and population growth based on survival,
+#'offtake, and fecundity parameters.
 #'
-#' @param initial_herd_structure Named numeric vector of length 6. Initial number of individuals in each of the 6
-#'   sex-age classes. Must be named with: \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}.
-#' @param max_simulation_years Integer. Maximum number of years to simulate.
-#' @param min_lambda_change Numeric. Threshold for minimal change in class-specific growth rates to reach
-#'   steady state.
-#' @param fecundity_female Numeric. Daily number of female births per adult female.
-#' @param fecundity_male Numeric. Daily number of male births per adult female.
-#' @param probability_death Named numeric vector of length 10. Daily death probabilities for 10 cohorts. Must be named
-#'   using: \code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{FC}, \code{MB}, \code{MJ}, \code{MS},
-#'   \code{MA}, \code{MC}.
-#' @param probability_offtake Named numeric vector of length 10. Daily offtake probabilities for 10 cohorts.
-#' Names must match those in \code{probability_death}.
-#' @param probability_growth Named numeric vector of length 10. Daily probability of transition
-#' to the next class for 10 cohorts. Names must match those in \code{probability_death}.
+#'
+#' @param initial_herd_structure Named numeric vector of length 6. Initial number of individuals in each of the 6 sex-age classes used 
+#' to bootstrap the steady-state simulation (# heads). 
+#' These values are used as starting points for the iterative simulation and do not affect the final steady-state results (only convergence speed). 
+#' Must be named with: \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}.
+#' @param max_simulation_years Numeric. Maximum number of years to simulate (years).
+#' @param min_lambda_change Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda). Iterations of the herd simulation stop when the absolute change in lambda between successive iterations falls below this threshold.
+#' @param fecundity_female Numeric. Daily number of female offspring per adult female (# offspring/day)
+#' @param fecundity_male Numeric. Daily number of male offspring per adult female (# offspring/day)
+#' @param probability_death Named numeric vector of length 10. Probability of animal dying within the model time interval for 10 cohorts (fraction) 
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).
+#' @param probability_offtake Named numeric vector of length 10. Probability that an animal will be removed from the herd within the model time interval for 10 cohorts (fraction).
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).
+#' @param probability_growth Named numeric vector of length 10. Probability of growing into the next age class for 10 cohorts (fraction)
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{days_to_steady_state}{Number of days until steady state is reached.}
-#'   \item{herd_structure}{Final share of each of the 8 sex-age cohorts.}
-#'   \item{cohort_share}{Final share of 6 grouped sex-age classes.}
-#'   \item{growth_rate_herd}{Annualized growth rate at steady state.}
+#'   \item{days_to_steady_state}{Numeric. Number of days required for the herd population structure to converge to a steady state, defined as the point at which successive iterations produce negligible changes in cohort proportions (days)}
+#'   \item{herd_structure}{Named numeric vector of length 8. Final steady-state share of each of 8 sex-age cohorts (\code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}) (fraction). Shares should sum to 1.}
+#'   \item{cohort_share}{Named numeric vector of length 6. Final steady-state share of 6 grouped sex-age cohorts  (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}, where `FJ = FB + FJ` and `MJ = MB + MJ`) (fraction). Shares should sum to 1.}
+#'   \item{growth_rate_herd}{Numeric. Annualized growth rate at which the herd reaches steady state (fraction)}
 #' }
 #'
 #' @export
@@ -362,30 +372,31 @@ simulate_steady_state_structure <- function(
 #' Project One Year of Steady-State Population Dynamics
 #'
 #' Simulates one year of population dynamics under steady-state assumptions using demographic parameters
-#' and returns population size statistics and offtake results.
+#' and returns population size statistics and offtake results. The steady state is defined as a constant 
+#' sex–age cohort structure over time, with population size potentially growing or declining at a constant rate.
 #'
-#' @param herd_size_total Numeric. Total population size at the start of the year.
-#' @param fecundity_female Numeric. Daily female births per adult female.
-#' @param fecundity_male Numeric. Daily male births per adult female.
-#' @param probability_death Named numeric vector of length 10. Daily death probabilities. Must be named using:
-#'   \code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{FC}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}, \code{MC}.
-#' @param probability_offtake Named numeric vector of length 10. Daily offtake probabilities.
-#' Names must match those in \code{probability_death}.
-#' @param probability_growth Named numeric vector of length 10. Transition probabilities to next age class.
-#' Names must match those in \code{probability_death}.
-#' @param growth_rate_herd Numeric. Annual population growth rate.
-#' @param herd_structure Named numeric vector of length 8. Final population share in 8 classes. Must be named:
-#'   \code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}.
-#' @param cohort_share Named numeric vector of length 6. Final population share in 6 grouped classes. Must be named:
-#'   \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}.
+#' @param herd_size_total Numeric. Total population size at the start of the year, including all cohorts (# heads)
+#' @param fecundity_female Numeric. Daily number of female offspring per adult female (# offspring/day)
+#' @param fecundity_male Numeric. Daily number of male offspring per adult female (# offspring/day)
+#' @param probability_death Named numeric vector of length 10. Probability of animal dying within the model time interval for 10 cohorts (fraction) 
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).
+#' @param probability_offtake Named numeric vector of length 10. Probability that an animal will be removed from the herd within the model time interval for 10 cohorts (fraction).
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).
+#' @param probability_growth Named numeric vector of length 10. Probability of growing into the next age class for 10 cohorts (fraction)
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).
+#' @param growth_rate_herd Numeric. Annualized growth rate at which the herd reaches steady state (fraction)
+#' @param herd_structure Named numeric vector of length 8. Final steady-state share of each of 8 sex-age cohorts (\code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}) (fraction). Shares should sum to 1.
+#' @param cohort_share Named numeric vector of length 6. Final steady-state share of 6 grouped sex-age cohorts  (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}, where `FJ = FB + FJ` and `MJ = MB + MJ`) (fraction). Shares should sum to 1.
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{cohort_stock_start}{Size in 6 sex-age classes at the start of the year.}
-#'   \item{cohort_stock_end_projected}{Size at year end (projected using growth rate).}
-#'   \item{cohort_stock_end_exact_simulated}{Size at year end (based on full simulation over 366 days).}
-#'   \item{cohort_stock_average}{Average population size over the year.}
-#'   \item{cohort_offtake_heads}{Total offtake over the year per sex-age class.}
+#'   \item{cohort_stock_start}{Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{cohort_stock_end_projected}{Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the end of the year, projected using the steady-state growth rate (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{cohort_stock_end_exact_simulated}{Numeric vector of length 10. Population size in each of 10 sex–age cohort at the end of the year, based on a demographic daily simulation over 365 days (# heads) 
+#'   (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+#'   \item{cohort_stock_average}{Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts over the year (# heads). Estimated from cohort_stock_start and cohort_stock_end_projected  (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{cohort_offtake_heads}{Numeric vector of length 10. Total number of animals removed from the herd over the year, by 10 sex–age cohorts (heads/year) 
+#'   (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
 #' }
 #'
 #' @export
@@ -534,24 +545,26 @@ project_population_size <- function(
 #' Summarise Offtake and Stock Variation for a Steady-State Year
 #'
 #' Computes annual offtake quantities and rates, as well as stock variation and their combined values
-#' across 6 sex-age classes based on steady-state population projections.
+#' across 6 sex-age classes based on steady-state population projections. The steady state is defined as a constant 
+#' sex–age cohort structure over time, with population size potentially growing or declining at a constant rate.
 #'
-#' @param cohort_stock_start Numeric vector of length 6. Population at start of year.
-#' @param cohort_stock_end_projected Numeric vector of length 6. Population at end of year.
-#' @param cohort_stock_average Numeric vector of length 6. Average population over the year.
-#' @param cohort_offtake_heads Numeric vector of length 10. Offtake counts from 10 sex-age classes.
-#' @param simulation_duration Numeric. Length of the assessment period (days).
+#' @param cohort_stock_start Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})
+#' @param cohort_stock_end_projected Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the end of the year, projected using the steady-state growth rate (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})
+#' @param cohort_stock_average Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts over the year (# heads). Estimated from cohort_stock_start and cohort_stock_end_projected  (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})
+#' @param cohort_offtake_heads Numeric vector of length 10. Total number of animals removed from the herd over the year, by 10 sex–age cohorts (heads/year) 
+#' (cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)
+#' @param simulation_duration Numeric. Length of the assessment period (days)
 #'
 #' @return A named list with:
 #' \describe{
-#'   \item{stock_variation_heads}{Difference between end and start population sizes.}
-#'   \item{offtake_heads}{Total number of individuals removed via offtake across 6 sex-age classes.}
-#'   \item{offtake_heads_assessment}{Total offtake over the assessment period.}
-#'   \item{offtake_rate_to_stock_start}{Offtake rate relative to starting population size.}
-#'   \item{offtake_rate_to_stock_average}{Offtake rate relative to average population size.}
-#'   \item{offtake_stock_variation_heads}{Sum of offtake and stock variation (SV).}
-#'   \item{offtake_stock_plus_variation_rate_to_stock_start}{SV rate relative to starting population size.}
-#'   \item{offtake_stock_plus_variation_rate_to_stock_average}{SV rate relative to average population size.}
+#'   \item{stock_variation_heads}{Numeric vector of length 6. Change in population size between the start and end of the year for each sex–age cohort (# heads) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}).}
+#'   \item{offtake_heads}{Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (heads/year) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{offtake_heads_assessment}{Numeric vector of length 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (heads/assessment period) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{offtake_rate_to_stock_start}{Numeric vector of length 6. Offtake rate relative to the starting population size in each sex–age cohort (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}) }
+#'   \item{offtake_rate_to_stock_average}{Numeric vector of length 6. Offtake rate relative to the average population size in each sex–age cohort (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{offtake_stock_variation_heads}{Numeric vector of length 6. Sum of offtake and stock variation for each sex–age cohort over the year (# heads) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{offtake_stock_plus_variation_rate_to_stock_start}{Numeric vector of length 6. Offtake plus stock-variation rate relative to starting population size (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+#'   \item{offtake_stock_plus_variation_rate_to_stock_average}{Numeric vector of length 6.  Offtake plus stock-variation rate relative to average population size (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
 #' }
 #'
 #' @export

--- a/R/herd_simulation_core_model.R
+++ b/R/herd_simulation_core_model.R
@@ -9,7 +9,7 @@
 #' @return A named list with two elements:
 #' \describe{
 #'   \item{fecundity_female}{Numeric. Daily number of female offspring per adult female (# offspring/day)}
-#'   \item{fecundity_male}{Numeric. Daily number of male offspring per adult female? (# offspring/day)}
+#'   \item{fecundity_male}{Numeric. Daily number of male offspring per adult female (# offspring/day)}
 #' }
 #' @examples
 #' compute_fecundity_rates(parturition_rate = 0.8, litter_size = 2, birth_fraction_female = 0.5)

--- a/R/run_herd_simulation.R
+++ b/R/run_herd_simulation.R
@@ -4,11 +4,13 @@
 #' sex–age herd structure compatible with downstream calculations in the Global Livestock
 #' Environmental Assessment Model (GLEAM). In addition to cohort population sizes, it derives
 #' population growth rates, and offtake numbers.
+#' The steady state is defined as a constant sex–age cohort structure over time,
+#' with population size potentially growing or declining at a constant rate. 
 #'
 #' @details
 #' The function operates under a \strong{steady-state assumption}: demographic parameters
 #' are constant over time, so the population converges to a stable cohort composition and
-#' a constant annual growth rate (\eqn{\lambda}). Once this regime is reached, the model
+#' a constant annual growth rate. Once this regime is reached, the model
 #' computes cohort population sizes (start/end/average), cohort shares, and offtake totals.
 #'
 #' A key feature of this implementation is that it applies demography at a \strong{daily}
@@ -63,30 +65,19 @@
 #' ## Steady state
 #'
 #' Under constant parameters, the cohort structure converges to a stable composition and a
-#' stable population growth rate (\eqn{\lambda}). This function seeks that steady state by
-#' iterating the demographic system starting from \code{initial_herd_structure} until changes in
-#' \eqn{\lambda} fall below \code{lambda_threshold_default}, or until \code{max_simulation_years} is reached.
-#'
-#' Once steady state is reached, the model projects cohort sizes over the assessment period and
-#' returns:
-#' \itemize{
-#'   \item cohort shares (\code{cohort_share})
-#'   \item cohort sizes at start/end/average (\code{cohort_stock_start}, \code{cohort_stock_end_projected},
-#'         \code{cohort_stock_average})
-#'   \item cohort offtake totals (\code{offtake_heads}) and assessment-scaled totals
-#'         (\code{offtake_heads_assessment})
-#'   \item daily transition probabilities (\code{probability_death}, \code{probability_offtake},
-#'         \code{probability_survival}, \code{probability_growth})
-#' }
+#' stable population growth rate. This function seeks that steady state by
+#' iterating the demographic system starting from \code{initial_herd_structure} until changes 
+#' in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{lambda_threshold_default}, 
+#' or until \code{max_simulation_years} is reached.
 #'
 #' @references
 #' Lesnoff, M. (2013). \emph{DYNMOD: A spreadsheet interface for demographic projections of tropical
 #' livestock populations, User’s manual}. CIRAD, Montpellier, France.
 #'
-#' @param cohort_level_data A `data.table` with mandatory columns:
+#' @param cohort_level_data A `data.table` with the one row per herd and cohort, and the following mandatory columns::
 #'   \describe{
 #'     \item{`herd_id`}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd.}
-#'     \item{`cohort_short`}{"Character scalar. Sex- and age-specific cohort code describing the production stage of the animals. Supported values include:
+#'     \item{`cohort_short`}{"Character. Sex- and age-specific cohort code describing the production stage of the animals. Supported values include:
 #'   \itemize{
 #'     \item \code{FA}: adult females (from age at first parturition)
 #'     \item \code{FS}: sub-adult females (from weaning to age at first parturition)
@@ -98,42 +89,36 @@
 #'       }
 #'     \item{`cohort_duration_days`}{Numeric vector of legth 6. Amount of time that each animal spends in a specific cohort (days).}
 #'     \item{`offtake_rate`}{Numeric vector of legth 6. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).}
-#'     \item{`death_rate`}{Numeric vector of legth 6. Fraction of deaths in a herd over a year for each sex-age class (fraction).}
+#'     \item{`death_rate`}{Numeric vector of legth 6. Fraction of deaths in a herd over a year for each sex-age cohort (fraction).}
 #'   }
-#' @param herd_level_data A `data.table` with one row per herd and mandatory columns:
+#' @param herd_level_data A `data.table` with one row per herd, and the following mandatory columns:
 #'   \describe{
-#'     \item{`herd_id`}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd. Must match `herd_id` values in `cohort_level_data`.}
-#'     \item{`parturition_rate`}{Numeric. Average annual number of parturitions per female animal (# parturitions/reproductive female/year). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
+#'     \item{`herd_id`}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd.}
+#'     \item{`parturition_rate`}{Numeric. Average annual number of parturitions per female animal (# parturitions/adult female/year). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
 #'     \item{`litter_size`}{Numeric. Average number of offspring born per parturition (# offsprings/parturition). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.}
 #'     \item{`birth_fraction_female`}{Numeric. Female birth fraction, defined as the probability that a newborn offspring is female (fraction). Can be calculated  as the number of female offspring born divided by the total number of offspring born.}
 #'     \item{`herd_size_total`}{Numeric. Total population size at the start of the year, including all cohorts (# heads).}
 #'   }
-#' @param initial_herd_structure A named numeric vector of initial population values used to
-#'   bootstrap the steady-state simulation. Must be named with cohort codes:
-#'   `c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30)`. These values are used
-#'   as starting points for the iterative simulation and do not affect the final steady-state
-#'   results (only convergence speed).
-#' @param max_simulation_years Integer. Maximum number of simulation years to run when seeking a
-#'   steady-state population structure. The simulation will stop earlier if convergence
-#'   is detected. Defaults to `100`.
-#' @param lambda_threshold_default Numeric. Tolerance threshold for detecting convergence in
-#'   population growth rate. When the change in growth rate (lambda) across consecutive
-#'   time steps falls below this threshold for all cohorts, steady-state is considered
-#'   reached. Defaults to `1e-9`.
+#' @param initial_herd_structure Named numeric vector of length 6. Initial number of individuals in each of the 6 sex-age cohorts used 
+#' to bootstrap the steady-state simulation (# heads).These values are used as starting points for the iterative simulation and 
+#' do not affect the final steady-state results (only convergence speed). Default is `c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30)`. 
+#' @param max_simulation_years Numeric. Maximum number of years to simulate (years). Defaults to `100`.
+#' @param lambda_threshold_default Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda). 
+#' Iterations of the herd simulation stop when the absolute change in lambda between successive iterations falls below this threshold. Defaults to `1e-9`.
 #' @param show_indicator Logical. Whether to display progress indicators during simulation.
 #'   Defaults to `TRUE`.
 #'@param simulation_duration Numeric. Length of the assessment period (days).
 #'
 #' @return A named list with two elements:
 #'   \describe{
-#'     \item{`cohort_level_results`}{A `data.table` with one row per cohort containing all original
+#'     \item{`cohort_level_results`}{A `data.table` with one row per herd and cohort containing all original
 #'       `cohort_level_data` columns plus the following simulation results:
 #'       \itemize{
-#'         \item `cohort_stock_size` - Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts (cohorts = (`FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)) (# heads).
+#'         \item `cohort_stock_size` - Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts (# heads) (cohorts = (`FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)).
 #'         This corresponds to `cohort_stock_start` returned by \code{\link{project_population_size}}, as it reflects the size of the population by cohort while preserving the total population size (`herd_size_total`) provided in the inputs.
-#'         \item `offtake_heads` - Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (cohorts = (`FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)) (heads/year).
-#'         \item `offtake_heads_assessment` - Numeric vector of legth 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (cohorts = (`FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)) (heads/assessment period).
-#'         \item `probability_growth` - Numeric vector of length 6. Probability of growing into the next age class for 6 cohorts (cohorts = (`FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)) (fraction).
+#'         \item `offtake_heads` - Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (heads/year) (cohorts = `FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`).
+#'         \item `offtake_heads_assessment` - Numeric vector of legth 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (heads/assessment period) (cohorts = `FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`).
+#'         \item `probability_growth` - Numeric vector of length 6. Probability of growing into the next age class for 6 cohorts (fraction). (cohorts = `FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)
 #'       }
 #'     }
 #'     \item{`herd_level_results`}{A `data.table` with one row per herd containing all original

--- a/R/run_herd_simulation.R
+++ b/R/run_herd_simulation.R
@@ -32,7 +32,8 @@
 #'
 #' Only adult females (\code{FA}) contribute to reproduction. Births are distributed between
 #' females and males using \code{birth_fraction_female}. Reproduction is assumed to be
-#' distributed over time (no birth pulse).
+#' distributed over time (no birth pulse). Daily fecundity rates are computed in
+#' \code{\link{compute_fecundity_rates}}.
 #'
 #' ## Dynamics and parameters
 #'
@@ -51,8 +52,8 @@
 #' ## Competing risks and conversion to daily probabilities
 #'
 #' Mortality and offtake are treated as **competing risks** within each cohort: at any time an
-#' animal can survive, die, or be offtaken. Annual inputs are converted to daily hazards and then
-#' daily probabilities to avoid bias from interference between processes.
+#' animal can survive, die, or be offtaken.Annual inputs are converted to daily hazards and then
+#' daily transition probabilities in \code{\link{compute_transition_probabilities}}.
 #'
 #' Internally, the model:
 #' \enumerate{
@@ -66,9 +67,23 @@
 #'
 #' Under constant parameters, the cohort structure converges to a stable composition and a
 #' stable population growth rate. This function seeks that steady state by
-#' iterating the demographic system starting from \code{initial_herd_structure} until changes 
+#' iterating the demographic system (see \code{\link{simulate_steady_state_structure}}) starting from \code{initial_herd_structure} until changes 
 #' in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{min_lambda_change},
 #' or until \code{max_simulation_years} is reached.
+#'
+#' ## Projection of population size
+#' 
+#' The steady-state solution obtained here provides:
+#' \itemize{
+#'   \item cohort shares used to scale herd-level population sizes,
+#'   \item a stable annual herd growth rate,
+#'   \item internally consistent death, offtake, and survival probabilities.
+#' }
+#'
+#' These outputs are subsequently used to project one year of population dynamics 
+#' (\code{\link{project_population_size}}) and to summarise annual offtake and stock variation
+#' (\code{\link{summarise_offtake}}).
+#' 
 #'
 #' @references
 #' Lesnoff, M. (2013). \emph{DYNMOD: A spreadsheet interface for demographic projections of tropical

--- a/R/run_herd_simulation.R
+++ b/R/run_herd_simulation.R
@@ -67,7 +67,7 @@
 #' Under constant parameters, the cohort structure converges to a stable composition and a
 #' stable population growth rate. This function seeks that steady state by
 #' iterating the demographic system starting from \code{initial_herd_structure} until changes 
-#' in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{lambda_threshold_default}, 
+#' in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{min_lambda_change},
 #' or until \code{max_simulation_years} is reached.
 #'
 #' @references
@@ -103,7 +103,7 @@
 #' to bootstrap the steady-state simulation (# heads).These values are used as starting points for the iterative simulation and 
 #' do not affect the final steady-state results (only convergence speed). Default is `c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30)`. 
 #' @param max_simulation_years Numeric. Maximum number of years to simulate (years). Defaults to `100`.
-#' @param lambda_threshold_default Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda). 
+#' @param min_lambda_change Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda).
 #' Iterations of the herd simulation stop when the absolute change in lambda between successive iterations falls below this threshold. Defaults to `1e-9`.
 #' @param show_indicator Logical. Whether to display progress indicators during simulation.
 #'   Defaults to `TRUE`.
@@ -167,7 +167,7 @@ run_herd_simulation <- function(
     herd_level_data,
     initial_herd_structure = c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30),
     max_simulation_years = 100,
-    lambda_threshold_default = 1e-9,
+    min_lambda_change = 1e-9,
     show_indicator = TRUE,
     simulation_duration = 365
 ) {
@@ -238,7 +238,7 @@ run_herd_simulation <- function(
     structure_result <- simulate_steady_state_structure(
       initial_herd_structure = initial_herd_structure,
       max_simulation_years = max_simulation_years,
-      min_lambda_change = lambda_threshold_default,
+      min_lambda_change = min_lambda_change,
       fecundity_female = fecundity_female,
       fecundity_male = fecundity_male,
       probability_death = transition_result$probability_death,

--- a/R/run_herd_simulation.R
+++ b/R/run_herd_simulation.R
@@ -118,7 +118,6 @@
 #'         This corresponds to `cohort_stock_start` returned by \code{\link{project_population_size}}, as it reflects the size of the population by cohort while preserving the total population size (`herd_size_total`) provided in the inputs.
 #'         \item `offtake_heads` - Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (heads/year) (cohorts = `FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`).
 #'         \item `offtake_heads_assessment` - Numeric vector of legth 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (heads/assessment period) (cohorts = `FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`).
-#'         \item `probability_growth` - Numeric vector of length 6. Probability of growing into the next age class for 6 cohorts (fraction). (cohorts = `FJ`, `FS`, `FA`, `MJ`, `MS`, `MA`)
 #'       }
 #'     }
 #'     \item{`herd_level_results`}{A `data.table` with one row per herd containing all original
@@ -129,6 +128,13 @@
 #'     }
 #'   }
 #'
+#' @seealso
+#' \code{\link{compute_fecundity_rates}},
+#' \code{\link{compute_transition_probabilities}},
+#' \code{\link{simulate_steady_state_structure}},
+#' \code{\link{project_population_size}},
+#' \code{\link{summarise_offtake}}
+#' 
 #' @examples
 #' \dontrun{
 #' # Load herd simulation inputs (cohort- and herd-level)
@@ -271,8 +277,7 @@ run_herd_simulation <- function(
         `:=`(
           cohort_stock_size = popsize_result$cohort_stock_start[cohort_name],
           offtake_heads = offtake_result$offtake_heads[cohort_name],
-          offtake_heads_assessment = offtake_result$offtake_heads_assessment[cohort_name],
-          probability_growth = transition_result$probability_growth[cohort_name]
+          offtake_heads_assessment = offtake_result$offtake_heads_assessment[cohort_name]
         )
       ]
     }

--- a/man/compute_fecundity_rates.Rd
+++ b/man/compute_fecundity_rates.Rd
@@ -17,7 +17,7 @@ compute_fecundity_rates(parturition_rate, litter_size, birth_fraction_female)
 A named list with two elements:
 \describe{
 \item{fecundity_female}{Numeric. Daily number of female offspring per adult female (# offspring/day)}
-\item{fecundity_male}{Numeric. Daily number of male offspring per adult female? (# offspring/day)}
+\item{fecundity_male}{Numeric. Daily number of male offspring per adult female (# offspring/day)}
 }
 }
 \description{

--- a/man/compute_fecundity_rates.Rd
+++ b/man/compute_fecundity_rates.Rd
@@ -7,17 +7,17 @@
 compute_fecundity_rates(parturition_rate, litter_size, birth_fraction_female)
 }
 \arguments{
-\item{parturition_rate}{Numeric. Parturition rate (probability of an adult female to give birth).}
+\item{parturition_rate}{Numeric. Average annual number of parturitions per female animal (# parturitions/adult female/year). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
 
-\item{litter_size}{Numeric. Prolificacy rate (mean number of offspring per parturition).}
+\item{litter_size}{Numeric. Average number of offspring born per parturition (# offsprings/parturition). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.}
 
-\item{birth_fraction_female}{Numeric. Female birth ratio (probability that an offspring is female).}
+\item{birth_fraction_female}{Numeric. Female birth fraction, defined as the probability that a newborn offspring is female (fraction). Can be calculated  as the number of female offspring born divided by the total number of offspring born.}
 }
 \value{
 A named list with two elements:
 \describe{
-\item{fecundity_female}{Daily number of female offspring per adult female.}
-\item{fecundity_male}{Daily number of male offspring per adult female.}
+\item{fecundity_female}{Numeric. Daily number of female offspring per adult female (# offspring/day)}
+\item{fecundity_male}{Numeric. Daily number of male offspring per adult female? (# offspring/day)}
 }
 }
 \description{

--- a/man/compute_transition_probabilities.Rd
+++ b/man/compute_transition_probabilities.Rd
@@ -11,24 +11,29 @@ compute_transition_probabilities(
 )
 }
 \arguments{
-\item{cohort_duration_days}{Numeric vector of length 6. Duration (in days) of each sex-age class.}
+\item{cohort_duration_days}{Numeric vector of length 6. Amount of time that each animal spends in a specific cohort (days).}
 
-\item{offtake_rate}{Numeric vector of length 6. Annual offtake rate for each sex-age class.}
+\item{offtake_rate}{Numeric vector of length 6. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).}
 
-\item{death_rate}{Numeric vector of length 6. Annual death rate for each sex-age class.}
+\item{death_rate}{Numeric vector of length 6. Fraction of deaths in a herd over a year for each sex-age cohort (fraction)}
 }
 \value{
 A named list with:
 \describe{
-\item{hazard_death}{Instantaneous mortality hazard rate for 6 sex-age classes.}
-\item{hazard_offtake}{Instantaneous offtake hazard rate for 6 sex-age classes.}
-\item{probability_death}{Daily death probability for 10 cohorts.}
-\item{probability_offtake}{Daily offtake probability for 10 cohorts.}
-\item{probability_survival}{Daily survival probability for 10 cohorts.}
-\item{probability_growth}{Probability of growing into the next age class for 10 cohorts.}
+\item{hazard_death}{Numeric vector of length 6. Instantaneous mortality hazard rate for the 6 sex–age cohorts. Represents the  risk of death per unit time (day⁻¹) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{hazard_offtake}{Numeric vector of length 6. Instantaneous offtake hazard rate for the 6 sex-age cohorts. Represents the risk to leave the herd through planned removals per unit of time (day⁻¹) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{probability_death}{Named numeric vector of length 10. Probability of animal dying within the model time interval for 10 cohorts (fraction).
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+\item{probability_offtake}{Named numeric vector of length 10. Probability that an animal will be removed from the herd within the model time interval for 10 cohorts (fraction).
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+\item{probability_survival}{Named numeric vector of length 10. Probability that an animal remains alive in the herd within the model time interval for 10 cohorts (fraction).
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+\item{probability_growth}{Named numeric vector of length 10. Probability of growing into the next age class for 10 cohorts (fraction)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
 }
 }
 \description{
 Calculates hazard rates and daily transition probabilities (death, offtake, survival, and growth)
-across 10 cohorts derived from 6 sex-age classes.
+across different sex-age cohorts. Converts annual inputs to daily hazards, then derives daily probabilities
+from those hazards.
 }

--- a/man/project_population_size.Rd
+++ b/man/project_population_size.Rd
@@ -17,40 +17,41 @@ project_population_size(
 )
 }
 \arguments{
-\item{herd_size_total}{Numeric. Total population size at the start of the year.}
+\item{herd_size_total}{Numeric. Total population size at the start of the year, including all cohorts (# heads)}
 
-\item{fecundity_female}{Numeric. Daily female births per adult female.}
+\item{fecundity_female}{Numeric. Daily number of female offspring per adult female (# offspring/day)}
 
-\item{fecundity_male}{Numeric. Daily male births per adult female.}
+\item{fecundity_male}{Numeric. Daily number of male offspring per adult female (# offspring/day)}
 
-\item{probability_death}{Named numeric vector of length 10. Daily death probabilities. Must be named using:
-\code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{FC}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}, \code{MC}.}
+\item{probability_death}{Named numeric vector of length 10. Probability of animal dying within the model time interval for 10 cohorts (fraction)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).}
 
-\item{probability_offtake}{Named numeric vector of length 10. Daily offtake probabilities.
-Names must match those in \code{probability_death}.}
+\item{probability_offtake}{Named numeric vector of length 10. Probability that an animal will be removed from the herd within the model time interval for 10 cohorts (fraction).
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).}
 
-\item{probability_growth}{Named numeric vector of length 10. Transition probabilities to next age class.
-Names must match those in \code{probability_death}.}
+\item{probability_growth}{Named numeric vector of length 10. Probability of growing into the next age class for 10 cohorts (fraction)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).}
 
-\item{growth_rate_herd}{Numeric. Annual population growth rate.}
+\item{growth_rate_herd}{Numeric. Annualized growth rate at which the herd reaches steady state (fraction)}
 
-\item{herd_structure}{Named numeric vector of length 8. Final population share in 8 classes. Must be named:
-\code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}.}
+\item{herd_structure}{Named numeric vector of length 8. Final steady-state share of each of 8 sex-age cohorts (\code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}) (fraction). Shares should sum to 1.}
 
-\item{cohort_share}{Named numeric vector of length 6. Final population share in 6 grouped classes. Must be named:
-\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}.}
+\item{cohort_share}{Named numeric vector of length 6. Final steady-state share of 6 grouped sex-age cohorts  (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}, where \code{FJ = FB + FJ} and \code{MJ = MB + MJ}) (fraction). Shares should sum to 1.}
 }
 \value{
 A named list with:
 \describe{
-\item{cohort_stock_start}{Size in 6 sex-age classes at the start of the year.}
-\item{cohort_stock_end_projected}{Size at year end (projected using growth rate).}
-\item{cohort_stock_end_exact_simulated}{Size at year end (based on full simulation over 366 days).}
-\item{cohort_stock_average}{Average population size over the year.}
-\item{cohort_offtake_heads}{Total offtake over the year per sex-age class.}
+\item{cohort_stock_start}{Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{cohort_stock_end_projected}{Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the end of the year, projected using the steady-state growth rate (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{cohort_stock_end_exact_simulated}{Numeric vector of length 10. Population size in each of 10 sex–age cohort at the end of the year, based on a demographic daily simulation over 365 days (# heads)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
+\item{cohort_stock_average}{Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts over the year (# heads). Estimated from cohort_stock_start and cohort_stock_end_projected  (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{cohort_offtake_heads}{Numeric vector of length 10. Total number of animals removed from the herd over the year, by 10 sex–age cohorts (heads/year)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
 }
 }
 \description{
 Simulates one year of population dynamics under steady-state assumptions using demographic parameters
-and returns population size statistics and offtake results.
+and returns population size statistics and offtake results. The steady state is defined as a constant
+sex–age cohort structure over time, with population size potentially growing or declining at a constant rate.
 }

--- a/man/run_herd_simulation.Rd
+++ b/man/run_herd_simulation.Rd
@@ -66,7 +66,6 @@ A named list with two elements:
 This corresponds to \code{cohort_stock_start} returned by \code{\link{project_population_size}}, as it reflects the size of the population by cohort while preserving the total population size (\code{herd_size_total}) provided in the inputs.
 \item \code{offtake_heads} - Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (heads/year) (cohorts = \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}).
 \item \code{offtake_heads_assessment} - Numeric vector of legth 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (heads/assessment period) (cohorts = \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}).
-\item \code{probability_growth} - Numeric vector of length 6. Probability of growing into the next age class for 6 cohorts (fraction). (cohorts = \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})
 }
 }
 \item{\code{herd_level_results}}{A \code{data.table} with one row per herd containing all original
@@ -179,4 +178,11 @@ print(results$herd_level_results)
 \references{
 Lesnoff, M. (2013). \emph{DYNMOD: A spreadsheet interface for demographic projections of tropical
 livestock populations, User’s manual}. CIRAD, Montpellier, France.
+}
+\seealso{
+\code{\link{compute_fecundity_rates}},
+\code{\link{compute_transition_probabilities}},
+\code{\link{simulate_steady_state_structure}},
+\code{\link{project_population_size}},
+\code{\link{summarise_offtake}}
 }

--- a/man/run_herd_simulation.Rd
+++ b/man/run_herd_simulation.Rd
@@ -15,10 +15,10 @@ run_herd_simulation(
 )
 }
 \arguments{
-\item{cohort_level_data}{A \code{data.table} with mandatory columns:
+\item{cohort_level_data}{A \code{data.table} with the one row per herd and cohort, and the following mandatory columns::
 \describe{
 \item{\code{herd_id}}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd.}
-\item{\code{cohort_short}}{"Character scalar. Sex- and age-specific cohort code describing the production stage of the animals. Supported values include:
+\item{\code{cohort_short}}{"Character. Sex- and age-specific cohort code describing the production stage of the animals. Supported values include:
 \itemize{
 \item \code{FA}: adult females (from age at first parturition)
 \item \code{FS}: sub-adult females (from weaning to age at first parturition)
@@ -30,32 +30,26 @@ run_herd_simulation(
 }
 \item{\code{cohort_duration_days}}{Numeric vector of legth 6. Amount of time that each animal spends in a specific cohort (days).}
 \item{\code{offtake_rate}}{Numeric vector of legth 6. Annual proportion of animals removed from the herd for each sex-age cohort (fraction).}
-\item{\code{death_rate}}{Numeric vector of legth 6. Fraction of deaths in a herd over a year for each sex-age class (fraction).}
+\item{\code{death_rate}}{Numeric vector of legth 6. Fraction of deaths in a herd over a year for each sex-age cohort (fraction).}
 }}
 
-\item{herd_level_data}{A \code{data.table} with one row per herd and mandatory columns:
+\item{herd_level_data}{A \code{data.table} with one row per herd, and the following mandatory columns:
 \describe{
-\item{\code{herd_id}}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd. Must match \code{herd_id} values in \code{cohort_level_data}.}
-\item{\code{parturition_rate}}{Numeric. Average annual number of parturitions per female animal (# parturitions/reproductive female/year). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
+\item{\code{herd_id}}{Character. Unique identifier for the herd, repeated for each cohort belonging to the same herd.}
+\item{\code{parturition_rate}}{Numeric. Average annual number of parturitions per female animal (# parturitions/adult female/year). A herd-level reproductive performance indicator calculated as the total number of parturitions (deliveries) occurring during a year divided by the number of adult females potentially able to give birth during that year.}
 \item{\code{litter_size}}{Numeric. Average number of offspring born per parturition (# offsprings/parturition). This value can be calculated as the total number of offspring born divided by the total number of parturitions during the year.}
 \item{\code{birth_fraction_female}}{Numeric. Female birth fraction, defined as the probability that a newborn offspring is female (fraction). Can be calculated  as the number of female offspring born divided by the total number of offspring born.}
 \item{\code{herd_size_total}}{Numeric. Total population size at the start of the year, including all cohorts (# heads).}
 }}
 
-\item{initial_herd_structure}{A named numeric vector of initial population values used to
-bootstrap the steady-state simulation. Must be named with cohort codes:
-\code{c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30)}. These values are used
-as starting points for the iterative simulation and do not affect the final steady-state
-results (only convergence speed).}
+\item{initial_herd_structure}{Named numeric vector of length 6. Initial number of individuals in each of the 6 sex-age cohorts used
+to bootstrap the steady-state simulation (# heads).These values are used as starting points for the iterative simulation and
+do not affect the final steady-state results (only convergence speed). Default is \code{c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30)}.}
 
-\item{max_simulation_years}{Integer. Maximum number of simulation years to run when seeking a
-steady-state population structure. The simulation will stop earlier if convergence
-is detected. Defaults to \code{100}.}
+\item{max_simulation_years}{Numeric. Maximum number of years to simulate (years). Defaults to \code{100}.}
 
-\item{lambda_threshold_default}{Numeric. Tolerance threshold for detecting convergence in
-population growth rate. When the change in growth rate (lambda) across consecutive
-time steps falls below this threshold for all cohorts, steady-state is considered
-reached. Defaults to \code{1e-9}.}
+\item{lambda_threshold_default}{Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda).
+Iterations of the herd simulation stop when the absolute change in lambda between successive iterations falls below this threshold. Defaults to \code{1e-9}.}
 
 \item{show_indicator}{Logical. Whether to display progress indicators during simulation.
 Defaults to \code{TRUE}.}
@@ -65,14 +59,14 @@ Defaults to \code{TRUE}.}
 \value{
 A named list with two elements:
 \describe{
-\item{\code{cohort_level_results}}{A \code{data.table} with one row per cohort containing all original
+\item{\code{cohort_level_results}}{A \code{data.table} with one row per herd and cohort containing all original
 \code{cohort_level_data} columns plus the following simulation results:
 \itemize{
-\item \code{cohort_stock_size} - Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts (cohorts = (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})) (# heads).
+\item \code{cohort_stock_size} - Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts (# heads) (cohorts = (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})).
 This corresponds to \code{cohort_stock_start} returned by \code{\link{project_population_size}}, as it reflects the size of the population by cohort while preserving the total population size (\code{herd_size_total}) provided in the inputs.
-\item \code{offtake_heads} - Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (cohorts = (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})) (heads/year).
-\item \code{offtake_heads_assessment} - Numeric vector of legth 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (cohorts = (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})) (heads/assessment period).
-\item \code{probability_growth} - Numeric vector of length 6. Probability of growing into the next age class for 6 cohorts (cohorts = (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})) (fraction).
+\item \code{offtake_heads} - Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (heads/year) (cohorts = \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}).
+\item \code{offtake_heads_assessment} - Numeric vector of legth 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (heads/assessment period) (cohorts = \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}).
+\item \code{probability_growth} - Numeric vector of length 6. Probability of growing into the next age class for 6 cohorts (fraction). (cohorts = \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})
 }
 }
 \item{\code{herd_level_results}}{A \code{data.table} with one row per herd containing all original
@@ -88,11 +82,13 @@ This function takes herd- and cohort-level demographic inputs and estimates a st
 sex–age herd structure compatible with downstream calculations in the Global Livestock
 Environmental Assessment Model (GLEAM). In addition to cohort population sizes, it derives
 population growth rates, and offtake numbers.
+The steady state is defined as a constant sex–age cohort structure over time,
+with population size potentially growing or declining at a constant rate.
 }
 \details{
 The function operates under a \strong{steady-state assumption}: demographic parameters
 are constant over time, so the population converges to a stable cohort composition and
-a constant annual growth rate (\eqn{\lambda}). Once this regime is reached, the model
+a constant annual growth rate. Once this regime is reached, the model
 computes cohort population sizes (start/end/average), cohort shares, and offtake totals.
 
 A key feature of this implementation is that it applies demography at a \strong{daily}
@@ -149,21 +145,10 @@ Internally, the model:
 \subsection{Steady state}{
 
 Under constant parameters, the cohort structure converges to a stable composition and a
-stable population growth rate (\eqn{\lambda}). This function seeks that steady state by
-iterating the demographic system starting from \code{initial_herd_structure} until changes in
-\eqn{\lambda} fall below \code{lambda_threshold_default}, or until \code{max_simulation_years} is reached.
-
-Once steady state is reached, the model projects cohort sizes over the assessment period and
-returns:
-\itemize{
-\item cohort shares (\code{cohort_share})
-\item cohort sizes at start/end/average (\code{cohort_stock_start}, \code{cohort_stock_end_projected},
-\code{cohort_stock_average})
-\item cohort offtake totals (\code{offtake_heads}) and assessment-scaled totals
-(\code{offtake_heads_assessment})
-\item daily transition probabilities (\code{probability_death}, \code{probability_offtake},
-\code{probability_survival}, \code{probability_growth})
-}
+stable population growth rate. This function seeks that steady state by
+iterating the demographic system starting from \code{initial_herd_structure} until changes
+in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{lambda_threshold_default},
+or until \code{max_simulation_years} is reached.
 }
 }
 \examples{

--- a/man/run_herd_simulation.Rd
+++ b/man/run_herd_simulation.Rd
@@ -9,7 +9,7 @@ run_herd_simulation(
   herd_level_data,
   initial_herd_structure = c(FJ = 100, FS = 50, FA = 30, MJ = 100, MS = 50, MA = 30),
   max_simulation_years = 100,
-  lambda_threshold_default = 1e-09,
+  min_lambda_change = 1e-09,
   show_indicator = TRUE,
   simulation_duration = 365
 )
@@ -48,7 +48,7 @@ do not affect the final steady-state results (only convergence speed). Default i
 
 \item{max_simulation_years}{Numeric. Maximum number of years to simulate (years). Defaults to \code{100}.}
 
-\item{lambda_threshold_default}{Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda).
+\item{min_lambda_change}{Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda).
 Iterations of the herd simulation stop when the absolute change in lambda between successive iterations falls below this threshold. Defaults to \code{1e-9}.}
 
 \item{show_indicator}{Logical. Whether to display progress indicators during simulation.
@@ -146,7 +146,7 @@ Internally, the model:
 Under constant parameters, the cohort structure converges to a stable composition and a
 stable population growth rate. This function seeks that steady state by
 iterating the demographic system starting from \code{initial_herd_structure} until changes
-in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{lambda_threshold_default},
+in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{min_lambda_change},
 or until \code{max_simulation_years} is reached.
 }
 }

--- a/man/run_herd_simulation.Rd
+++ b/man/run_herd_simulation.Rd
@@ -108,7 +108,8 @@ represented by six cohorts:
 
 Only adult females (\code{FA}) contribute to reproduction. Births are distributed between
 females and males using \code{birth_fraction_female}. Reproduction is assumed to be
-distributed over time (no birth pulse).
+distributed over time (no birth pulse). Daily fecundity rates are computed in
+\code{\link{compute_fecundity_rates}}.
 }
 
 \subsection{Dynamics and parameters}{
@@ -129,8 +130,8 @@ natural mortality excluding offtake.
 \subsection{Competing risks and conversion to daily probabilities}{
 
 Mortality and offtake are treated as \strong{competing risks} within each cohort: at any time an
-animal can survive, die, or be offtaken. Annual inputs are converted to daily hazards and then
-daily probabilities to avoid bias from interference between processes.
+animal can survive, die, or be offtaken.Annual inputs are converted to daily hazards and then
+daily transition probabilities in \code{\link{compute_transition_probabilities}}.
 
 Internally, the model:
 \enumerate{
@@ -145,9 +146,23 @@ Internally, the model:
 
 Under constant parameters, the cohort structure converges to a stable composition and a
 stable population growth rate. This function seeks that steady state by
-iterating the demographic system starting from \code{initial_herd_structure} until changes
+iterating the demographic system (see \code{\link{simulate_steady_state_structure}}) starting from \code{initial_herd_structure} until changes
 in cohort-specific growth rates of sex–age cohort proportions (\eqn{\lambda}) fall below \code{min_lambda_change},
 or until \code{max_simulation_years} is reached.
+}
+
+\subsection{Projection of population size}{
+
+The steady-state solution obtained here provides:
+\itemize{
+\item cohort shares used to scale herd-level population sizes,
+\item a stable annual herd growth rate,
+\item internally consistent death, offtake, and survival probabilities.
+}
+
+These outputs are subsequently used to project one year of population dynamics
+(\code{\link{project_population_size}}) and to summarise annual offtake and stock variation
+(\code{\link{summarise_offtake}}).
 }
 }
 \examples{

--- a/man/simulate_steady_state_structure.Rd
+++ b/man/simulate_steady_state_structure.Rd
@@ -16,38 +16,41 @@ simulate_steady_state_structure(
 )
 }
 \arguments{
-\item{initial_herd_structure}{Named numeric vector of length 6. Initial number of individuals in each of the 6
-sex-age classes. Must be named with: \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}.}
+\item{initial_herd_structure}{Named numeric vector of length 6. Initial number of individuals in each of the 6 sex-age classes used
+to bootstrap the steady-state simulation (# heads).
+These values are used as starting points for the iterative simulation and do not affect the final steady-state results (only convergence speed).
+Must be named with: \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}.}
 
-\item{max_simulation_years}{Integer. Maximum number of years to simulate.}
+\item{max_simulation_years}{Numeric. Maximum number of years to simulate (years).}
 
-\item{min_lambda_change}{Numeric. Threshold for minimal change in class-specific growth rates to reach
-steady state.}
+\item{min_lambda_change}{Numeric. Convergence threshold for changes in cohort-specific growth rates of sex–age cohort proportions (lambda). Iterations of the herd simulation stop when the absolute change in lambda between successive iterations falls below this threshold.}
 
-\item{fecundity_female}{Numeric. Daily number of female births per adult female.}
+\item{fecundity_female}{Numeric. Daily number of female offspring per adult female (# offspring/day)}
 
-\item{fecundity_male}{Numeric. Daily number of male births per adult female.}
+\item{fecundity_male}{Numeric. Daily number of male offspring per adult female (# offspring/day)}
 
-\item{probability_death}{Named numeric vector of length 10. Daily death probabilities for 10 cohorts. Must be named
-using: \code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{FC}, \code{MB}, \code{MJ}, \code{MS},
-\code{MA}, \code{MC}.}
+\item{probability_death}{Named numeric vector of length 10. Probability of animal dying within the model time interval for 10 cohorts (fraction)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).}
 
-\item{probability_offtake}{Named numeric vector of length 10. Daily offtake probabilities for 10 cohorts.
-Names must match those in \code{probability_death}.}
+\item{probability_offtake}{Named numeric vector of length 10. Probability that an animal will be removed from the herd within the model time interval for 10 cohorts (fraction).
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).}
 
-\item{probability_growth}{Named numeric vector of length 10. Daily probability of transition
-to the next class for 10 cohorts. Names must match those in \code{probability_death}.}
+\item{probability_growth}{Named numeric vector of length 10. Probability of growing into the next age class for 10 cohorts (fraction)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling).}
 }
 \value{
 A named list with:
 \describe{
-\item{days_to_steady_state}{Number of days until steady state is reached.}
-\item{herd_structure}{Final share of each of the 8 sex-age cohorts.}
-\item{cohort_share}{Final share of 6 grouped sex-age classes.}
-\item{growth_rate_herd}{Annualized growth rate at steady state.}
+\item{days_to_steady_state}{Numeric. Number of days required for the herd population structure to converge to a steady state, defined as the point at which successive iterations produce negligible changes in cohort proportions (days)}
+\item{herd_structure}{Named numeric vector of length 8. Final steady-state share of each of 8 sex-age cohorts (\code{FB}, \code{FJ}, \code{FS}, \code{FA}, \code{MB}, \code{MJ}, \code{MS}, \code{MA}) (fraction). Shares should sum to 1.}
+\item{cohort_share}{Named numeric vector of length 6. Final steady-state share of 6 grouped sex-age cohorts  (\code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}, where \code{FJ = FB + FJ} and \code{MJ = MB + MJ}) (fraction). Shares should sum to 1.}
+\item{growth_rate_herd}{Numeric. Annualized growth rate at which the herd reaches steady state (fraction)}
 }
 }
 \description{
-Simulates population dynamics over time until a steady-state is reached. Tracks age-class structure and
-population growth based on survival, offtake, and fecundity parameters.
+Simulates population dynamics over time until a steady state is reached.
+The steady state is defined as a constant sex–age cohort structure over time,
+with population size potentially growing or declining at a constant rate.
+Tracks sex–age cohort structure and population growth based on survival,
+offtake, and fecundity parameters.
 }

--- a/man/summarise_offtake.Rd
+++ b/man/summarise_offtake.Rd
@@ -13,30 +13,32 @@ summarise_offtake(
 )
 }
 \arguments{
-\item{cohort_stock_start}{Numeric vector of length 6. Population at start of year.}
+\item{cohort_stock_start}{Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the start of the year (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
 
-\item{cohort_stock_end_projected}{Numeric vector of length 6. Population at end of year.}
+\item{cohort_stock_end_projected}{Numeric vector of length 6. Population size in each of the 6 sex–age cohorts at the end of the year, projected using the steady-state growth rate (# heads). (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
 
-\item{cohort_stock_average}{Numeric vector of length 6. Average population over the year.}
+\item{cohort_stock_average}{Numeric vector of length 6. Average population size in each of the 6 sex–age cohorts over the year (# heads). Estimated from cohort_stock_start and cohort_stock_end_projected  (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
 
-\item{cohort_offtake_heads}{Numeric vector of length 10. Offtake counts from 10 sex-age classes.}
+\item{cohort_offtake_heads}{Numeric vector of length 10. Total number of animals removed from the herd over the year, by 10 sex–age cohorts (heads/year)
+(cohorts= \code{FB}: Female Birth, \code{FJ}: Female Juvenile, \code{FS}: Female Sub-adult, \code{FA}: Female Adult, \code{FC}: Female Culling, \code{MB}: Male Birth, \code{MJ}: Male Juvenile, \code{MS}: Male Sub-adult, \code{MA}: Male Adult, \code{MC}: Male Culling)}
 
-\item{simulation_duration}{Numeric. Length of the assessment period (days).}
+\item{simulation_duration}{Numeric. Length of the assessment period (days)}
 }
 \value{
 A named list with:
 \describe{
-\item{stock_variation_heads}{Difference between end and start population sizes.}
-\item{offtake_heads}{Total number of individuals removed via offtake across 6 sex-age classes.}
-\item{offtake_heads_assessment}{Total offtake over the assessment period.}
-\item{offtake_rate_to_stock_start}{Offtake rate relative to starting population size.}
-\item{offtake_rate_to_stock_average}{Offtake rate relative to average population size.}
-\item{offtake_stock_variation_heads}{Sum of offtake and stock variation (SV).}
-\item{offtake_stock_plus_variation_rate_to_stock_start}{SV rate relative to starting population size.}
-\item{offtake_stock_plus_variation_rate_to_stock_average}{SV rate relative to average population size.}
+\item{stock_variation_heads}{Numeric vector of length 6. Change in population size between the start and end of the year for each sex–age cohort (# heads) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}).}
+\item{offtake_heads}{Numeric vector of length 6. Total number of animals removed via offtake over the year, aggregated to 6 sex–age cohorts (heads/year) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{offtake_heads_assessment}{Numeric vector of length 6. Total number of animals removed via offtake over the assessment period, aggregated to 6 sex–age cohorts (heads/assessment period) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{offtake_rate_to_stock_start}{Numeric vector of length 6. Offtake rate relative to the starting population size in each sex–age cohort (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA}) }
+\item{offtake_rate_to_stock_average}{Numeric vector of length 6. Offtake rate relative to the average population size in each sex–age cohort (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{offtake_stock_variation_heads}{Numeric vector of length 6. Sum of offtake and stock variation for each sex–age cohort over the year (# heads) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{offtake_stock_plus_variation_rate_to_stock_start}{Numeric vector of length 6. Offtake plus stock-variation rate relative to starting population size (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
+\item{offtake_stock_plus_variation_rate_to_stock_average}{Numeric vector of length 6.  Offtake plus stock-variation rate relative to average population size (fraction) (cohorts= \code{FJ}, \code{FS}, \code{FA}, \code{MJ}, \code{MS}, \code{MA})}
 }
 }
 \description{
 Computes annual offtake quantities and rates, as well as stock variation and their combined values
-across 6 sex-age classes based on steady-state population projections.
+across 6 sex-age classes based on steady-state population projections. The steady state is defined as a constant
+sex–age cohort structure over time, with population size potentially growing or declining at a constant rate.
 }


### PR DESCRIPTION
- Documentation of the herd module was updated to refine function descriptions and align variable definitions with Central SharePoint, as per OP#311.
- Minor amendment to variables returned by the run function: **probability_growth** was removed from the list of returned variables.

- [ ] **To be fixed**: the variable **min_lambda_change** (in _herd_simulation_core_model.R_) is called **lambda_threshold_default** in _run_herd_simulation.R_. The second one is assigned to the default value (line 170), then it is assigned to min_lambda_change (line 241). While the default value is used only in the run function, this is valid also for other arguments (e.g. **max_simulation_years**), that are not called differently in the core and the run codes. Is there a reason for this, or can lambda_threshold_default be renamed to min_lambda_change? The default value is reported in the variable description of the run function, as in similar cases. 